### PR TITLE
フラッシュメッセージ実装

### DIFF
--- a/app/controllers/maps_controller.rb
+++ b/app/controllers/maps_controller.rb
@@ -1,4 +1,8 @@
 class MapsController < ApplicationController
   def new
   end
+
+  def index
+    flash[:notice] = "フラッシュテスト"
+  end
 end

--- a/app/javascript/controllers/flash_controller.js
+++ b/app/javascript/controllers/flash_controller.js
@@ -1,0 +1,14 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="flash"
+export default class extends Controller {
+  connect() {
+    requestAnimationFrame(() => {
+      this.element.classList.remove("opacity-0", "-translate-y-2")
+    })
+
+    setTimeout(() => {
+      this.element.classList.add("opacity-0")
+    }, 1500)
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -4,5 +4,8 @@
 
 import { application } from "./application"
 
+import FlashController from "./flash_controller"
+application.register("flash", FlashController)
+
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,6 +24,7 @@
   </head>
 
   <body class="bg-green-900 min-h-[200vh]" >
+    <%= render "shared/flash_message" %>
     <main class="font-sans">
       <%= yield %>
     </main>

--- a/app/views/maps/index.html.erb
+++ b/app/views/maps/index.html.erb
@@ -1,0 +1,3 @@
+<div class="text-red-500">
+  地図一覧です
+</div>

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,0 +1,20 @@
+<% flash.each do |message_type, message| %>
+  <% if message_type == "notice" %>
+    <% flash_color = "bg-orange-400" %>
+  <% elsif message_type == "alert" %>
+    <% flash_color = "bg-red-500" %>
+  <% elsif message_type == "info" %>
+    <% flash_color = "bg-sky-500" %>
+  <% end %>
+
+  <div data-controller="flash" class="
+    flash-message <%= message_type %>
+    fixed top-6 left-1/2 -translate-x-1/2 z-50 px-4 py-2 rounded-xl min-w-[180px] max-w-[90vw] text-center
+    text-white text-sm font-medium shadow-lg select-none
+    opacity-0 -translate-y-2
+    transition-all duration-300 transition-opacity
+    <%= flash_color %>
+  ">
+    <%= message %>
+  </div>
+<% end %>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -2,17 +2,17 @@
   <div class="mx-auto max-w-md px-4 pointer-events-auto">
     <div class="bg-white/70 backdrop-blur-md rounded-2xl shadow-lg px-6 py-3">
       <nav class="flex">
-        <%= link_to root_path, class: tab_class(root_path) do %>
+        <%= link_to new_map_path, class: tab_class(new_map_path) do %>
           <%= lucide_icon('map') %>
           <span class="text-xs">地図</span>
         <% end %>
 
-        <%= link_to "###", class: tab_class("###") do %>
+        <%= link_to maps_path, class: tab_class(maps_path) do %>
           <%= lucide_icon('history') %>
           <span class="text-xs">履歴</span>
         <% end %>
 
-        <%= link_to "###", class: tab_class("###") do %>
+        <%= link_to root_path, class: tab_class(root_path) do %>
           <%= lucide_icon('users') %>
           <span class="text-xs">みんなの地図</span>
         <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,6 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   # root "posts#index"
-  resources :maps, only: [ :new ]
+  resources :maps, only: [ :new, :index ]
   root "maps#new"
 end


### PR DESCRIPTION
## issue
- close: #8 
- 関連issue:
  - #7 

## 実装内容
- shared/_flash_message.html.erb にフラッシュメッセージを実装
- aplication.html.erb に render で表示
- stimulus の flash_controller.js で表示される時のアニメーション、自動消失、消える時のアニメーションを実装

## issueとの差分
- フラッシュが表示される時のアニメーションも追加

## 動作確認方法
- maps#index の仮ページとルーティングを設定して、flash[:notice] がページ遷移で表示されるか確認

## 補足
- フラッシュメッセージは1つしか表示されない想定のため、複数表示されるとメッセージが重なるように実装されている
