### PR TITLE
map_share_uuid カラムをDBに追加

### DIFF
--- a/db/migrate/20251214072840_add_uuid_to_users.rb
+++ b/db/migrate/20251214072840_add_uuid_to_users.rb
@@ -1,0 +1,7 @@
+class AddUuidToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :map_share_uuid, :uuid, null: false, default: -> { "gen_random_uuid()" }
+
+    add_index :users, :map_share_uuid, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_12_14_002415) do
+ActiveRecord::Schema[7.2].define(version: 2025_12_14_072840) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -26,7 +26,9 @@ ActiveRecord::Schema[7.2].define(version: 2025_12_14_002415) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.uuid "map_share_uuid", default: -> { "gen_random_uuid()" }, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["map_share_uuid"], name: "index_users_on_map_share_uuid", unique: true
     t.index ["public_uid"], name: "index_users_on_public_uid", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
## issue
- close: #37 
- 関連issue:
  - #7 #10 

## 実装内容
- Usersテーブルに map_share_uuid カラムを追加

## issueとの差分
- なし

## 動作確認方法
- rails c でUserデータを作成時に map_share_uuid が自動生成されていることを確認

## 補足
- 既存のpublic_uidをセキュリティの面からユーザーページ用のカラムとして使用
- そして累計地図を表示するためのuuidとして、既存のpublic_uidを使用することとする
