### PR TITLE
Mapモデル作成

### DIFF
--- a/app/models/map.rb
+++ b/app/models/map.rb
@@ -1,0 +1,17 @@
+class Map < ApplicationRecord
+  # enum 定義
+  # 地図の公開ステータス
+  # 非公開:0, 限定公開:10, 公開:20
+  enum :status, { private: 0, unlisted: 10, public: 20 }, prefix: :visibility
+
+  # バリデーション定義
+  validates :user_id, :name, :activity_time, :total_distance, :status, :started_at, presence: true
+
+  # アソシエーション定義
+  belongs_to :user
+
+  # 初期値を設定
+  attribute :started_at, :datetime, default: -> { Time.current }
+  # 地図名のデフォルト値は、開始位置から取得するように後で設定を変える
+  attribute :name, :string, default: "デフォルト地図"
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,6 +14,9 @@ class User < ApplicationRecord
   # UUIDは保存の直前にDBが生成してくれるので、ここでは設定しない
   validates :nickname, :role, :map_privacy, presence: true
 
+  # アソシエーション定義
+  has_many :maps, dependent: :destroy
+
   # Devise の機能をオーバーライド
   # ゲスト以外の時だけメールアドレスを必須にする
   def email_required?

--- a/db/migrate/20251222234925_create_maps.rb
+++ b/db/migrate/20251222234925_create_maps.rb
@@ -1,0 +1,32 @@
+class CreateMaps < ActiveRecord::Migration[7.2]
+  def change
+    create_table :maps do |t|
+      t.references :user, null: false, foreign_key: true
+
+      # 地図の名前。デフォルト値はrailsで設定する
+      t.string :name, null: false
+
+      # 活動時間(秒)
+      t.integer :activity_time, null: false, default: 0
+
+      # 地図記録中の距離(m)
+      t.integer :total_distance, null: false, default: 0
+
+      # 地図のURL用
+      t.uuid :public_uid, null: false, default: -> { "gen_random_uuid()" }
+
+      # 地図のステータス(非公開:0,限定公開:10,公開:20)
+      t.integer :status, null: false, default: 0
+
+      # 記録開始時刻(アプリで設定)
+      t.datetime :started_at, null: false
+
+      # 記録終了時刻(デフォルトなし)
+      t.datetime :ended_at, null: true
+
+      t.timestamps
+    end
+
+    add_index :maps, :public_uid, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,24 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_12_15_135824) do
+ActiveRecord::Schema[7.2].define(version: 2025_12_22_234925) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "maps", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "name", null: false
+    t.integer "activity_time", default: 0, null: false
+    t.integer "total_distance", default: 0, null: false
+    t.uuid "public_uid", default: -> { "gen_random_uuid()" }, null: false
+    t.integer "status", default: 0, null: false
+    t.datetime "started_at", null: false
+    t.datetime "ended_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["public_uid"], name: "index_maps_on_public_uid", unique: true
+    t.index ["user_id"], name: "index_maps_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email"
@@ -32,4 +47,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_12_15_135824) do
     t.index ["public_uid"], name: "index_users_on_public_uid", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
+
+  add_foreign_key "maps", "users"
 end


### PR DESCRIPTION
## issue
- close: #14 
- 関連issue:
  - #15 #12 

## 実装内容
- マイグレーションをしてmapsテーブルを作成
- map.rbを作成してマップモデルを作成
- enumを定義
- バリデーションを定義
- アソシエーションを定義
- atrributeでアプリから初期値を設定

## issueとの差分
- アソシエーションの定義を追加
- atrributeを使用したアプリからの初期値設定を追加

## 動作確認方法
- rails c でデータを作成できるか確認
- バリデーションが機能しているか確認

## 補足
- 地図のデフォルト名は、後で地名から動的に取得できるように変更
