### PR TITLE
デバウンスでアイコン消失実装

### DIFF
--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -446,9 +446,10 @@ export default class extends Controller {
     }
   }
 
+  // 現在地を取得できているのかチェック
   checkGeolocate(event){
-    if(this.currentLng && this.currentLat) return;
-    event.preventDefault();
+    if(this.currentLng && this.currentLat) return; // 現在地が取得できているのであれば何もしない
+    event.preventDefault();                        // 現在地が取得できていない場合はeventを行わないようにする
   }
 
   fogInit(){

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,6 +27,7 @@
   </head>
 
   <body class="" data-controller="ui" data-ui-map-outlet="#main-map">
+    <div class="fixed inset-0 z-50 hidden" data-ui-target="uiOverlay" data-action="click->ui#clearUiOverlay"></div>
     <%= yield :header %>
     <main class="font-sans">
       <%= yield %>


### PR DESCRIPTION
## issue
- close: #18 
- 関連issue:
  - #12 

## 実装内容
- 探索中に一定時間操作をしなかった場合にアイコンが消えるように実装
- 画面を触ったら時間がリセットされてまたアイコンが消えるまで計測するようにデバウンスで実装

## issueとの差分
- 各種ボタンは以前のイシューで追加していたので、ここでは触れず

## 動作確認方法
- 実際の画面で動作に不具合がないか確認

## 補足
- 記録中はアイコンが一定時間で消えるようになっているので、記録中に各種ボタンでの動作を導入するときは注意
