### PR TITLE
ボトムシート実装

### DIFF
--- a/app/controllers/bottom_sheets_controller.rb
+++ b/app/controllers/bottom_sheets_controller.rb
@@ -1,0 +1,8 @@
+class BottomSheetsController < ApplicationController
+  def show
+    respond_to do |format|
+      # format.html { redirect_to root_path }
+      format.turbo_stream
+    end
+  end
+end

--- a/app/helpers/bottom_sheets_helper.rb
+++ b/app/helpers/bottom_sheets_helper.rb
@@ -1,0 +1,2 @@
+module BottomSheetsHelper
+end

--- a/app/javascript/controllers/bottom_sheet_controller.js
+++ b/app/javascript/controllers/bottom_sheet_controller.js
@@ -1,0 +1,24 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="bottom-sheet"
+export default class extends Controller {
+  static targets = [ "bottomSheetBox", "bottomSheetBackdrop" ]
+
+  connect() {
+    requestAnimationFrame(() => {
+      this.element.classList.remove("opacity-0")
+      this.bottomSheetBoxTarget.classList.remove("translate-y-60")
+    })
+  }
+
+  close() {
+    requestAnimationFrame(() => {
+      this.element.classList.add("opacity-0")
+      this.bottomSheetBoxTarget.classList.add("translate-y-60")
+    })
+
+    this.bottomSheetBoxTarget.addEventListener("transitionend", () => {
+      this.element.remove();
+    }, { once: true });
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -4,6 +4,9 @@
 
 import { application } from "./application"
 
+import BottomSheetController from "./bottom_sheet_controller"
+application.register("bottom-sheet", BottomSheetController)
+
 import CopyController from "./copy_controller"
 application.register("copy", CopyController)
 

--- a/app/views/api/v1/trips/create.turbo_stream.erb
+++ b/app/views/api/v1/trips/create.turbo_stream.erb
@@ -3,5 +3,5 @@
     <div id="trip-id-receiver" data-ui-target="tripIdReceiver" data-trip-id="<%= @trip.id %>"></div>
   <% end %>
 <% end %>
-<%= turbo_stream.replace "end-trip-button-container", partial: "shared/end_trip_button", locals: { trip: @trip } %>
+<%= turbo_stream.update "end-trip-button-container", partial: "shared/end_trip_button", locals: { trip: @trip } %>
 <%= turbo_stream.replace "flash", partial: "shared/flash_message" %>

--- a/app/views/bottom_sheets/_bottom_sheet.html.erb
+++ b/app/views/bottom_sheets/_bottom_sheet.html.erb
@@ -1,0 +1,52 @@
+<div class="fixed inset-0 min-h-screen pointer-events-none w-full z-40 flex justify-center items-center opacity-0 transition-all duration-300 p-10" data-controller="bottom-sheet">
+
+  <%# バックドロップ %>
+  <div class="absolute inset-0 bg-black/50 z-0 pointer-events-auto" data-bottom-sheet-target="bottomSheetBackdrop" data-action="click->bottom-sheet#close"></div>
+
+  <%# --- ボトムシート全体 --- %>
+  <div class="fixed inset-x-0 bottom-0 z-10 rounded-t-[2rem] bg-[#FFFBE6] pb-11 pt-4 shadow-[0_-5px_20px_rgba(0,0,0,0.1)] transition-transform translate-y-60 duration-500 pointer-events-auto" data-bottom-sheet-target="bottomSheetBox">
+
+    <%# --- ドラッグハンドル（つまみ） --- %>
+    <div class="mx-auto mb-6 h-1.5 w-12 rounded-full bg-gray-400"></div>
+
+    <%# --- タイトル --- %>
+    <%# <div class="mb-8 text-center text-lg font-bold text-gray-900">
+      過去の地図に思い出を記録する
+    </div> %>
+
+    <%# --- アクションボタンエリア --- %>
+    <div class="flex flex-col items-start space-y-4 pl-8">
+
+      <%# タイトル編集ボタン %>
+      <button class="flex items-center gap-3 rounded-full bg-[#FFE4C4] px-3 py-2 text-sm font-medium text-gray-600 transition hover:bg-[#ffd8a8]">
+        <div class="flex items-center justify-center text-orange-400">
+          <%= lucide_icon("square-pen") %>
+        </div>
+        <span>地図のタイトルを編集</span>
+      </button>
+
+      <%# 公開設定・シェアボタン %>
+      <button class="flex items-center gap-3 rounded-full bg-[#FFE4C4] px-3 py-2 text-sm font-medium text-gray-600 transition hover:bg-[#ffd8a8]">
+        <div class="flex items-center justify-center text-orange-400">
+          <%= lucide_icon("share-2") %>
+        </div>
+        <span>公開設定・シェア</span>
+      </button>
+
+      <%# 地図削除ボタン %>
+      <button class="flex items-center gap-3 rounded-full bg-[#FFE4C4] px-3 py-2 text-sm font-medium text-gray-600 transition hover:bg-[#ffd8a8]">
+        <div class="flex items-center justify-center text-red-500">
+          <%= lucide_icon("trash-2") %>
+        </div>
+        <span class="text-red-500">この地図を削除する</span>
+      </button>
+
+    </div>
+
+    <%# --- 閉じるボタン（右下固定） --- %>
+    <button type="button" class="absolute bottom-8 right-6 flex h-16 w-16 flex-col items-center justify-center rounded-full bg-white text-gray-500 shadow-lg transition active:scale-95" data-action="click->bottom-sheet#close">
+      <%= lucide_icon('x') %>
+    </button>
+
+  </div>
+</div>

--- a/app/views/bottom_sheets/_bottom_sheets_shell.html.erb
+++ b/app/views/bottom_sheets/_bottom_sheets_shell.html.erb
@@ -1,0 +1,2 @@
+<div id="bottom-sheet-container">
+</div>

--- a/app/views/bottom_sheets/show.turbo_stream.erb
+++ b/app/views/bottom_sheets/show.turbo_stream.erb
@@ -1,0 +1,1 @@
+<%= turbo_stream.update "bottom-sheet-container", partial: "bottom_sheets/bottom_sheet" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,6 +35,7 @@
     <% if show_footer? %>
       <%= render "shared/footer" %>
     <% end %>
+    <%= render "bottom_sheets/bottom_sheets_shell" %>
     <%= render "shared/modal_shell" %>
     <%= render "shared/flash_message" %>
   </body>

--- a/app/views/trips/show.html.erb
+++ b/app/views/trips/show.html.erb
@@ -11,12 +11,14 @@
 
     <%# タイトル %>
     <div class="text-xl font-bold text-gray-800">
-      <%= @trip.name %>
+      <%= @trip&.name %>
     </div>
 
     <%# 右側の「…」ボタン %>
-    <%= link_to "#", class: "absolute right-1 px-4 py-1.5" do %>
-      <%= lucide_icon("ellipsis-vertical", class: "transition text-gray-900 hover:text-gray-700 active:scale-95")%>
+    <% if @trip %>
+      <%= link_to trip_bottom_sheets_path(@trip), class: "absolute right-1 px-4 py-1.5", data: { turbo_stream: true } do %>
+        <%= lucide_icon("ellipsis-vertical", class: "transition text-gray-900 hover:text-gray-700 active:scale-95")%>
+      <% end %>
     <% end %>
   </header>
 
@@ -26,9 +28,9 @@
       data-controller="history-map"
       class="absolute inset-0 h-full w-full"
       data-maptiler-key="<%= Rails.application.credentials.dig(:maptiler, :api_key) %>"
-      data-history-map-longitude-value="<%= @first_footprint.longitude %>"
-      data-history-map-latitude-value="<%= @first_footprint.latitude %>"
-      data-history-map-visited-geohashes-value="<%= @visited_geohashes.to_json %>"
+      data-history-map-longitude-value="<%= @first_footprint&.longitude %>"
+      data-history-map-latitude-value="<%= @first_footprint&.latitude %>"
+      data-history-map-visited-geohashes-value="<%= @visited_geohashes&.to_json %>"
     >
       <div class="fixed bg-white w-full h-[130%] -bottom-[30%] inset-0 z-20 transition-transform duration-[2000ms] opacity-100 pointer-events-none ease-in-out
                   [mask-image:linear-gradient(to_bottom,black_80%,transparent)]"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,7 +26,10 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   # root "posts#index"
   resources :trips, only: [ :new, :index, :show ] do
-    patch :status, on: :member
+    member do
+      patch :status
+    end
+    resource :bottom_sheets, only: %i[ show ]
   end
   post "decisions", to: "decisions#create", as: :decisions
   get "location_denied", to: "tutorials#location_denied", as: :location_denied

--- a/test/controllers/bottom_sheets_controller_test.rb
+++ b/test/controllers/bottom_sheets_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class BottomSheetsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## issue
- close: #22 
- 関連issue:
  - #23 

## 実装内容
- ボトムシート実装
- bottom_sheetsコントローラー作成
- showアクション実装
- stimulus bottom_sheet_controller.js 作成
- connect() close()を使用して、ボトムシート表示時の上下移動を実装
- bottom_sheets/_bottom_sheet.html.erbにボトムシート本体を表示するのパーシャルを作成
- 地図詳細表示画面の右上のボタンからボトムシートを表示できるように実装

## issueとの差分
- なし

## 動作確認方法
- 実際にブラウザで操作して確認

## 補足
- 各種ボタンの表示設定は行なっていないので、機能実装時にユーザーの状態によって表示状態を変更
