### PR TITLE
地図削除機能修正

### DIFF
--- a/app/controllers/trips_controller.rb
+++ b/app/controllers/trips_controller.rb
@@ -89,7 +89,7 @@ class TripsController < ApplicationController
       end
     end
 
-    if @trip
+    if @trip.destroy
       redirect_to trips_path, notice: "地図を削除しました"
     else
       flash.now[:alert] = "地図の削除に失敗しました"


### PR DESCRIPTION
## issue
- close: #67 
- 関連issue:
  - #23 

## 実装内容
- 地図削除機能が機能していなかったので、機能するよう修正
- trips#destroyにテストのため.destroyを消していたので追記して削除可能に

## issueとの差分
- なし

## 動作確認方法
- ブラウザで削除できるか確認
- ログでも削除がされているのか確認
