### PR TITLE
マップ表示時のオーバーレイ修正

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,10 +11,12 @@
     "maplibre",
     "maplibregl",
     "maptiler",
+    "moveend",
     "ngeohash",
     "referer",
     "strftime",
     "styleimagemissing",
-    "stylesheet"
+    "stylesheet",
+    "zoomend"
   ]
 }


### PR DESCRIPTION
## issue
- close: #80

## 実装内容
- zoomend時に発火するズーム固定イベントの追加
- clearMapOverlay関数を地図の中心が現在地に近くなってから削除するように変更

## issueとの差分
- ズーム固定も追加

## 動作確認方法
- 実際にブラウザで確認

## 補足
- ズーム固定は以前不具合があったのと同じ実装となっているので、ちゃんと動作するのか実際にスマホで使用して確認すること
