### PR TITLE
地図履歴タイトル編集機能実装

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,6 +11,7 @@
     "maplibre",
     "maplibregl",
     "maptiler",
+    "maxlength",
     "moveend",
     "ngeohash",
     "referer",

--- a/app/controllers/trips_controller.rb
+++ b/app/controllers/trips_controller.rb
@@ -33,6 +33,53 @@ class TripsController < ApplicationController
     end
   end
 
+  def edit_title
+    @trip = current_user&.trips&.find_by(id: params[:id])
+
+    if @trip.nil?
+      flash.now[:alert] = "権限がありません"
+      return respond_to do |format|
+        format.html { redirect_to root_path }
+        format.turbo_stream { render "shared/flash_message" }
+      end
+    end
+
+    respond_to do |format|
+      format.html { redirect_to root_path }
+      format.turbo_stream
+    end
+  end
+
+  def update_title
+    @trip = current_user&.trips&.find_by(id: params[:id])
+
+    if @trip.nil?
+      flash.now[:alert] = "権限がありません"
+      return respond_to do |format|
+        format.html { head :not_acceptable }
+        format.turbo_stream { render "shared/flash_message" }
+      end
+    end
+
+    if @trip.update(name: trip_param_title[:name])
+      respond_to do |format|
+        format.html { head :not_acceptable }
+        format.turbo_stream do
+          flash.now[:notice] = "タイトルを更新しました"
+          render
+        end
+      end
+    else
+      respond_to do |format|
+        format.html { head :not_acceptable }
+        format.turbo_stream do
+          flash.now[:alert] = "タイトルの更新に失敗しました"
+          render "shared/flash_and_error"
+        end
+      end
+    end
+  end
+
   def edit_status
     @trip = current_user&.trips&.find_by(id: params[:id])
 
@@ -130,5 +177,9 @@ class TripsController < ApplicationController
 
   def trip_param_status
     params.require(:trip).permit(:status)
+  end
+
+  def trip_param_title
+    params.require(:trip).permit(:name)
   end
 end

--- a/app/javascript/controllers/error_controller.js
+++ b/app/javascript/controllers/error_controller.js
@@ -1,0 +1,17 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="error"
+export default class extends Controller {
+  connect() {
+    requestAnimationFrame(() => {
+      this.element.classList.remove("opacity-0", "-translate-y-2")
+    })
+
+    setTimeout(() => {
+      this.element.classList.add("opacity-0")
+      this.element.addEventListener("transitionend", () => {
+        this.element.remove();
+      }, { once: true });
+    }, 1500)
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -13,6 +13,9 @@ application.register("copy", CopyController)
 import DispatchController from "./dispatch_controller"
 application.register("dispatch", DispatchController)
 
+import ErrorController from "./error_controller"
+application.register("error", ErrorController)
+
 import FlashController from "./flash_controller"
 application.register("flash", FlashController)
 

--- a/app/models/trip.rb
+++ b/app/models/trip.rb
@@ -10,6 +10,9 @@ class Trip < ApplicationRecord
   # started_at, datetime,null: false、地図の作成開始時刻
   # ended_at, datetime、地図の作成終了時刻
 
+  # 定数定義
+  TITLE_MAX_LENGTH = 100
+
   # enum 定義
   # 地図の公開ステータス
   # 非公開:0, 限定公開:10, 公開:20
@@ -17,6 +20,10 @@ class Trip < ApplicationRecord
 
   # バリデーション定義
   validates :user_id, :name, :activity_time, :total_distance, :status, :started_at, presence: true
+  validates :name,
+    presence: true,
+    length: { maximum: TITLE_MAX_LENGTH },
+    format: { without: /\R/, message: "に改行は使えません" }
 
   # アソシエーション定義
   belongs_to :user

--- a/app/views/bottom_sheets/_bottom_sheet.html.erb
+++ b/app/views/bottom_sheets/_bottom_sheet.html.erb
@@ -18,12 +18,20 @@
     <div class="flex flex-col items-start gap-4 pl-8">
 
       <%# タイトル編集ボタン %>
-      <button class="flex items-center gap-3 rounded-full bg-[#FFE4C4] px-3 py-2 text-sm font-medium text-gray-600 transition hover:bg-[#ffd8a8]">
-        <div class="flex items-center justify-center text-orange-400">
-          <%= lucide_icon("square-pen") %>
-        </div>
-        <span>地図のタイトルを編集</span>
-      </button>
+      <% if @trip && @trip.user_id == current_user&.id %>
+        <%= button_to edit_title_trip_path(@trip),
+              id: "edit-title-button",
+              method: :get,
+              params: { format: :turbo_stream },
+              form: { class: "contents" },
+              data: { action: "click->bottom-sheet#close" },
+              class: "flex items-center gap-3 rounded-full bg-[#FFE4C4] px-3 py-2 text-sm font-medium text-gray-600 transition hover:bg-[#ffd8a8]" do %>
+          <div class="flex items-center justify-center text-orange-400">
+            <%= lucide_icon("square-pen") %>
+          </div>
+          <span>地図のタイトルを編集</span>
+        <% end %>
+      <% end %>
 
       <%# 公開設定・シェアボタン %>
       <% if @trip && @trip.user_id == current_user&.id %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -38,5 +38,10 @@
     <%= render "bottom_sheets/bottom_sheets_shell" %>
     <%= render "shared/modal_shell" %>
     <%= render "shared/flash_message" %>
+    <div id="error-root" class="fixed inset-0 z-50 pointer-events-none">
+      <div id="error-container" class="pointer-events-auto fixed top-6 left-1/2 -translate-x-1/2">
+        <%= render "shared/error_messages" %>
+      </div>
+    </div>
   </body>
 </html>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,0 +1,11 @@
+<%# locals: (object: nil) %>
+
+<% if object %>
+  <% if object&.errors&.any? %>
+    <% object.errors.full_messages.each do |msg| %>
+      <div data-controller="error" class="error px-4 py-2 mb-2 rounded-xl min-w-[180px] max-w-[90vw] text-center text-white text-sm font-medium shadow-lg select-none opacity-0 -translate-y-2 transition-all duration-300 bg-red-500">
+        <%= msg %>
+      </div>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/shared/flash_and_error.turbo_stream.erb
+++ b/app/views/shared/flash_and_error.turbo_stream.erb
@@ -1,0 +1,2 @@
+<%= turbo_stream.replace "flash", partial: "shared/flash_message" %>
+<%= turbo_stream.append "error-container", partial: "shared/error_messages", locals: { object: @trip } %>

--- a/app/views/trips/_edit_title.html.erb
+++ b/app/views/trips/_edit_title.html.erb
@@ -1,0 +1,9 @@
+<div id="<%= "map-title-" + @trip&.public_uid %>" class="flex-1 text-center text-xl font-bold text-gray-800 px-2">
+  <%= form_with url: update_title_trip_path(@trip), class: "flex items-center gap-3",method: :patch, scope: :trip do |form| %>
+    <div class="flex-1 min-w-0">
+      <%= form.text_field :name, maxlength: Trip::TITLE_MAX_LENGTH, class: "w-full text-center py-1 min-w-0" %>
+    </div>
+
+    <%= form.submit "確定", class: "shrink-0 cursor-pointer rounded-full bg-orange-400 px-4 py-1.5 text-sm font-bold text-white shadow transition hover:bg-orange-500 active:scale-95" %>
+  <% end %>
+</div>

--- a/app/views/trips/_title.html.erb
+++ b/app/views/trips/_title.html.erb
@@ -1,0 +1,3 @@
+<div id="<%= "map-title-" + @trip&.public_uid %>" class="flex-1 text-center text-xl font-bold text-gray-800 truncate px-2">
+  <%= @trip&.name %>
+</div>

--- a/app/views/trips/edit_title.turbo_stream.erb
+++ b/app/views/trips/edit_title.turbo_stream.erb
@@ -1,0 +1,4 @@
+<% target_id = "map-title-" + @trip.public_uid %>
+<%= turbo_stream.replace target_id, partial: "trips/edit_title" %>
+<%= turbo_stream.replace "flash", partial: "shared/flash_message" %>
+<%= turbo_stream.append "error-container", partial: "shared/error_messages", locals: { object: @trip } %>

--- a/app/views/trips/show.html.erb
+++ b/app/views/trips/show.html.erb
@@ -2,24 +2,28 @@
 <div class="h-screen bg-[#FFFBE6] flex flex-col">
 
   <%# --- ヘッダー部分 --- %>
-  <header class="sticky top-0 z-10 flex items-center justify-center bg-gray-300 py-2 px-4 shadow-sm">
+  <header class="sticky top-0 z-10 flex items-center justify-between bg-gray-300 py-2 px-4 shadow-sm gap-2">
 
     <%# 左端の戻るボタン %>
-    <%= link_to @back_url, class: "absolute left-1 px-4 py-1.5" do %>
-      <%= lucide_icon("arrow-left", class: "transition text-gray-900 hover:text-gray-700 active:scale-95")%>
-    <% end %>
-
-    <%# タイトル %>
-    <div class="text-xl font-bold text-gray-800">
-      <%= @trip&.name %>
+    <div class="flex-none">
+      <%= link_to @back_url, class: "block py-1.5" do %>
+        <%= lucide_icon("arrow-left", class: "transition text-gray-900 hover:text-gray-700 active:scale-95 stroke-[2.5]")%>
+      <% end %>
     </div>
 
+    <%# タイトル %>
+    <%= render "trips/title" %>
+
     <%# 右側の「…」ボタン %>
-    <% if @trip %>
-      <%= link_to trip_bottom_sheets_path(@trip), class: "absolute right-1 px-4 py-1.5", data: { turbo_stream: true } do %>
-        <%= lucide_icon("ellipsis-vertical", class: "transition text-gray-900 hover:text-gray-700 active:scale-95")%>
+    <div class="flex-none">
+      <% if @trip %>
+        <%= link_to trip_bottom_sheets_path(@trip), class: "block py-1.5", data: { turbo_stream: true } do %>
+          <%= lucide_icon("ellipsis-vertical", class: "transition text-gray-900 hover:text-gray-700 active:scale-95")%>
+        <% end %>
+      <% else %>
+        <div class="w-8"></div>
       <% end %>
-    <% end %>
+    </div>
   </header>
 
   <%# --- マップ部分 --- %>

--- a/app/views/trips/update_title.turbo_stream.erb
+++ b/app/views/trips/update_title.turbo_stream.erb
@@ -1,0 +1,3 @@
+<% target_id = "map-title-" + @trip.public_uid %>
+<%= turbo_stream.replace target_id, partial: "trips/title" %>
+<%= turbo_stream.replace "flash", partial: "shared/flash_message" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  get "stimulus/error"
   namespace :guest do
     post "sessions/create"
   end
@@ -30,6 +31,8 @@ Rails.application.routes.draw do
       get "confirm_destroy", to: "trips#confirm_destroy"
       patch :status
       get :edit_status
+      get :edit_title
+      patch :update_title
     end
     resource :bottom_sheets, only: %i[ show ]
   end


### PR DESCRIPTION
## issue
- close: #85 

## 実装内容
- tirps_controller.rbにedit_titleアクションを実装し、地図のタイトル編集フォームを表示できるよう実装
- tirps_controller.rbにupdate_titleアクションを実装し、編集フォームから地図のタイトルを更新できるよう実装
- 地図のタイトルにバリデーションを実装
  - 文字数を100文字まで
  - 空禁止
  - 改行禁止
- [_bottom_sheet.html.erb](https://github.com/yuuki2014/white-map/compare/feature/85-edit-title?expand=1#diff-96b3576d209f6dba3687508ef308bb800d6920e9ae26f3b812ce1b61e11a2c6f)の地図のタイトル編集ボタンを、地図の作成者しか出来ないよう実装
- [application.html.erb](https://github.com/yuuki2014/white-map/compare/feature/85-edit-title?expand=1#diff-f43fe075643e681b2c01c2f853bb0c4299d135b47fcbd4da96890d521c49e3eb)にエラーメッセージを表示する受け皿を用意
- エラーメッセージを表示するパーシャルを作成
- エラーメッセージを自動で消すstimulusコントローラーを実装
- タイトル編集用パーシャルを作成
- タイトル表示用パーシャルを作成

## issueとの差分
- エラーメッセージ表示部分を追加
- tripのnameのバリデーションを追加

## 動作確認方法
- 実際にブラウザとログで確認