### PR TITLE
累計地図API追加

### DIFF
--- a/app/controllers/api/v1/my_maps_controller.rb
+++ b/app/controllers/api/v1/my_maps_controller.rb
@@ -1,0 +1,7 @@
+class Api::V1::MyMapsController < ApplicationController
+  def show
+    geohashes = current_user&.cumulative_geohashes
+
+    render json: { geohashes: geohashes || [] }
+  end
+end

--- a/app/javascript/controllers/ui_controller.js
+++ b/app/javascript/controllers/ui_controller.js
@@ -7,7 +7,20 @@ const EVENTS = [ "click", "touchstart", "pointerdown" ]
 // Connects to data-controller="ui"
 export default class extends Controller {
   static outlets = [ "map" ]
-  static targets = [ "footer", "leftButtonContainer", "rightNormalButtonContainer", "rightRecordingButtonContainer", "pauseButtonContainer", "bottomSheet", "playButton", "pauseButton", "tripIdReceiver", "uiOverlay" ]
+  static targets = [
+    "footer",
+    "leftButtonContainer",
+    "rightNormalButtonContainer",
+    "rightRecordingButtonContainer",
+    "pauseButtonContainer",
+    "bottomSheet",
+    "playButton",
+    "pauseButton",
+    "tripIdReceiver",
+    "uiOverlay",
+    "cumulativeButtonActive",
+    "cumulativeButtonInactive",
+  ]
   static values = { status: String,
                     tripId: String
                   }
@@ -102,6 +115,7 @@ export default class extends Controller {
     this.statusValue = STATUS.ENDED
     this.mapOutlet.setStatus(this.statusValue);
     this.mapOutlet.resetFog();
+    this.mapOutlet.setCumulativeGeohashesAndFeature(this.mapOutlet.cumulativeGeohashes, this.mapOutlet.cumulativeFeature);
 
     this.documentRemoveHiddenTimer();
   }
@@ -116,10 +130,10 @@ export default class extends Controller {
         if (this.hasPlayButtonTarget) {
           this.playButtonTarget.classList.remove("hidden")
           this.pauseButtonContainerTarget.classList.add("translate-y-[calc(100%+6rem)]")
-          this.rightNormalButtonContainerTarget.classList.remove("translate-x-full")
+          this.rightNormalButtonContainerTarget.classList.remove("translate-x-[calc(100%+8px)]")
           this.pauseButtonTarget.classList.add("hidden")
           this.leftButtonContainerTarget.classList.add("-translate-x-full")
-          this.rightRecordingButtonContainerTarget.classList.add("translate-x-full")
+          this.rightRecordingButtonContainerTarget.classList.add("translate-x-[calc(100%+8px)]")
         }
         if (this.hasBottomSheetTarget) {
           this.bottomSheetTarget.classList.remove("translate-y-full")
@@ -130,8 +144,8 @@ export default class extends Controller {
         this.playButtonTarget.classList.add("hidden")
         this.pauseButtonTarget.classList.remove("hidden")
         this.leftButtonContainerTarget.classList.remove("-translate-x-full")
-        this.rightNormalButtonContainerTarget.classList.add("translate-x-full")
-        this.rightRecordingButtonContainerTarget.classList.remove("translate-x-full")
+        this.rightNormalButtonContainerTarget.classList.add("translate-x-[calc(100%+8px)]")
+        this.rightRecordingButtonContainerTarget.classList.remove("translate-x-[calc(100%+8px)]")
         this.bottomSheetTarget.classList.add("translate-y-full")
         this.pauseButtonContainerTarget.classList.add("translate-y-[calc(100%+6rem)]")
         break;
@@ -164,12 +178,12 @@ export default class extends Controller {
     this.maplibreTopContainer.addEventListener("transitionend", this._handleTransitionEnd, { signal: this.transitionEvents.signal, once: true });
 
     this.leftButtonContainerTarget.classList.add("-translate-x-full")
-    this.rightRecordingButtonContainerTarget.classList.add("translate-x-full")
+    this.rightRecordingButtonContainerTarget.classList.add("translate-x-[calc(100%+8px)]")
   }
 
   visibleUi(){
     this.leftButtonContainerTarget.classList.remove("-translate-x-full")
-    this.rightRecordingButtonContainerTarget.classList.remove("translate-x-full")
+    this.rightRecordingButtonContainerTarget.classList.remove("translate-x-[calc(100%+8px)]")
 
     if(this.maplibreTopContainer){
       this.maplibreTopContainer = document.querySelector(".maplibregl-ctrl-group")
@@ -215,6 +229,40 @@ export default class extends Controller {
         this.hiddenIcon();
       }
     }, HIDDEN_TIMEOUT);
+  }
+
+  async cumulativeModeOn(){
+    if (this.hasMapOutlet && !this.mapOutlet.mapInitEnd) return;
+
+    this.cumulativeButtonInactiveTargets.forEach(el => {
+      el.classList.add("hidden");
+    });
+    this.cumulativeButtonActiveTargets.forEach(el => {
+      el.classList.remove("hidden");
+    });
+
+    if (this.hasMapOutlet) {
+      await this.mapOutlet.cumulativeModeOn();
+    }
+  }
+
+  cumulativeModeOff(){
+    if (this.hasMapOutlet && !this.mapOutlet.mapInitEnd) return;
+
+    this.cumulativeButtonActiveTargets.forEach(el => {
+      el.classList.add("hidden");
+    });
+    this.cumulativeButtonInactiveTargets.forEach(el => {
+      el.classList.remove("hidden");
+    });
+
+    if (this.hasMapOutlet){
+      this.mapOutlet.cumulativeModeOff();
+    }
+  }
+
+  disableCumulative(){
+    this.cumulativeModeOff()
   }
 
   disconnect(){

--- a/app/models/footprint.rb
+++ b/app/models/footprint.rb
@@ -1,3 +1,16 @@
+# == Schema Information
+#
+# Table name: footprints
+#
+#  id          :bigint           not null, primary key
+#  trip_id     :bigint           not null
+#  latitude    :float            not null
+#  longitude   :float            not null
+#  geohash     :string           not null
+#  recorded_at :datetime         not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+
 class Footprint < ApplicationRecord
   # アソシエーション定義
   belongs_to :trip

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -72,6 +72,10 @@ class User < ApplicationRecord
     end
   end
 
+  def cumulative_geohashes
+    footprints.distinct.pluck(:geohash)
+  end
+
   # User モデルの :id を public_uidに
   def to_param
     public_uid

--- a/app/views/api/v1/trips/_end_check_modal.html.erb
+++ b/app/views/api/v1/trips/_end_check_modal.html.erb
@@ -39,8 +39,8 @@
             まだ続ける
           </div>
         </button>
-        <% if trip_id %>
-          <%= form_with model: @trip, url: api_v1_trip_path(trip_id), method: :patch, data: { action: "submit->modal#close", turbo: true } do |f| %>
+        <% if trip_id.present? %>
+          <%= form_with url: api_v1_trip_path(trip_id), method: :patch, scope: :trip, data: { action: "submit->modal#close", turbo: true } do |f| %>
             <%= f.button type: "submit", class: "" do %>
               保存して終了
             <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -26,7 +26,7 @@
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
   </head>
 
-  <body class="" data-controller="ui" data-ui-map-outlet="#main-map">
+  <body id="ui" class="" data-controller="ui" data-ui-map-outlet="#main-map">
     <div class="fixed inset-0 z-50 hidden" data-ui-target="uiOverlay" data-action="click->ui#clearUiOverlay"></div>
     <%= yield :header %>
     <main class="font-sans">

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -24,7 +24,7 @@
       </div>
 
       <%# 右側ノーマルボタンコンテナ %>
-      <div class="absolute bottom-full right-0 pr-4 mb-3 pointer-events-auto duration-500" data-ui-target="rightNormalButtonContainer">
+      <div class="absolute bottom-full right-0 pr-4 mb-3 flex flex-col-reverse gap-3 pointer-events-auto duration-500" data-ui-target="rightNormalButtonContainer">
 
         <%# 探索開始ボタン %>
         <%= form_with model: @trip, url: api_v1_trips_path, method: :post, data: { action: "submit->ui#checkGeolocate", turbo: true } do |f| %>
@@ -36,10 +36,27 @@
           <% end %>
         <% end %>
 
+        <%# 累計地図表示ボタン %>
+        <div class="flex flex-col">
+
+          <%= tag.button type: "button",
+            data: { action: "click->ui#cumulativeModeOn", ui_target: "cumulativeButtonInactive" },
+            class: "btn btn-primary bg-yellow-400/80 hover:bg-yellow500/80 text-black p-3 rounded-full shadow-lg active:scale-95 transition" do %>
+            <%= lucide_icon('map') %>
+          <% end %>
+
+          <%= tag.button type: "button",
+            data: { action: "click->ui#cumulativeModeOff", ui_target: "cumulativeButtonActive"  },
+            class: "btn btn-primary bg-yellow-400/80 text-black p-3 rounded-full shadow-lg hover:bg-yellow-500/80 active:scale-95 transition ring-2 ring-orange-400 ring-offset-2 ring-offset-white hidden" do %>
+            <%= lucide_icon('map') %>
+          <% end %>
+
+        </div>
+
       </div>
 
       <%# 右側探索中ボタンコンテナ %>
-      <div class="absolute bottom-full right-0 pr-4 mb-3 flex flex-col-reverse gap-3 pointer-events-auto duration-500 translate-x-full" data-ui-target="rightRecordingButtonContainer">
+      <div class="absolute bottom-full right-0 pr-4 mb-3 flex flex-col-reverse gap-3 pointer-events-auto duration-500 translate-x-[calc(100%+8px)]" data-ui-target="rightRecordingButtonContainer">
 
         <%# 現在地ボタン %>
         <%= tag.button type: "button",
@@ -56,11 +73,21 @@
         <% end %>
 
         <%# 累計地図表示ボタン %>
-        <%= tag.button type: "button",
-          data: { action: "" },
-          class: "btn btn-primary bg-yellow-400/80 text-black p-3 rounded-full shadow-lg hover:bg-yellow-500/80 active:scale-95 transition" do %>
-          <%= lucide_icon('map') %>
-        <% end %>
+        <div class="flex flex-col">
+
+          <%= tag.button type: "button",
+            data: { action: "click->ui#cumulativeModeOn", ui_target: "cumulativeButtonInactive" },
+            class: "btn btn-primary bg-yellow-400/80 text-black p-3 rounded-full shadow-lg hover:bg-yellow-500/80 active:scale-95 transition" do %>
+            <%= lucide_icon('map') %>
+          <% end %>
+
+          <%= tag.button type: "button",
+            data: { action: "click->ui#cumulativeModeOff", ui_target: "cumulativeButtonActive"  },
+            class: "btn btn-primary bg-yellow-400/80 text-black p-3 rounded-full shadow-lg hover:bg-yellow-500/80 active:scale-95 transition ring-2 ring-orange-400 ring-offset-2 ring-offset-white hidden" do %>
+            <%= lucide_icon('map') %>
+          <% end %>
+
+        </div>
 
       </div>
 

--- a/app/views/trips/new.html.erb
+++ b/app/views/trips/new.html.erb
@@ -1,5 +1,5 @@
 <div class="relative h-screen w-full">
-  <div id="main-map" data-controller="map" class="absolute inset-0 h-full w-full" data-maptiler-key="<%= Rails.application.credentials.dig(:maptiler, :api_key) %>">
+  <div id="main-map" data-controller="map" data-map-ui-outlet="#ui" class="absolute inset-0 h-full w-full" data-maptiler-key="<%= Rails.application.credentials.dig(:maptiler, :api_key) %>">
     <div class="fixed bg-white inset-0 z-20 transition-opacity duration-1000 opacity-100" data-map-target="mapOverlay"></div>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,6 +46,7 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v1 do
+      resource :my_map, only: :show
       resources :trips, only: %i[ create update ] do
         member do
           get :end_check

--- a/test/controllers/api/v1/my_maps_controller_test.rb
+++ b/test/controllers/api/v1/my_maps_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class Api::V1::MyMapsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## issue
- close: #26 

## 実装内容
- pi::V1::MyMaps#showに今までの累計のgeohashを返す機能を実装
- ルーティング設定
- map_controller.jsに累計地図を表示する機能を実装
- 画面上のボタンを押して累計地図との表示の切り替えを出来るようにui_controller.jsに実装
- _footer.html.erbに累計地図表示ボタンのアクティブの切り替えを追加

## issueとの差分
- 画面に反映させるように各種機能を修正、追加

## 動作確認方法
- ブラウザとログでエラーが出ないよう確認
