### PR TITLE
累計地図表示ページ作成

### DIFF
--- a/app/controllers/my_maps_controller.rb
+++ b/app/controllers/my_maps_controller.rb
@@ -1,0 +1,6 @@
+class MyMapsController < ApplicationController
+  def show
+    @first_footprint = current_user&.footprints.first
+    @visited_geohashes = current_user&.cumulative_geohashes || []
+  end
+end

--- a/app/controllers/trips_controller.rb
+++ b/app/controllers/trips_controller.rb
@@ -8,9 +8,7 @@ class TripsController < ApplicationController
     if @trip.present?
       if @trip.user_id == current_user&.id || @trip.visibility_unlisted? || @trip.visibility_public?
         @first_footprint = @trip.footprints.first
-        @visited_geohashes =  @trip.footprints.flat_map do |footprint|
-                        [ footprint.geohash ] + GeoHash.neighbors(footprint.geohash)
-                      end.uniq
+        @visited_geohashes =  @trip.footprints.distinct.pluck(:geohash)
 
         render
       else

--- a/app/views/my_maps/show.html.erb
+++ b/app/views/my_maps/show.html.erb
@@ -1,0 +1,40 @@
+<%# 全体の背景コンテナ（クリーム色） %>
+<div class="h-screen bg-[#FFFBE6] flex flex-col">
+
+  <%# --- ヘッダー部分 --- %>
+  <header class="sticky top-0 z-10 flex items-center justify-between bg-gray-300 py-2 px-4 shadow-sm gap-2">
+
+    <%# 左端の戻るボタン %>
+    <div class="flex-none">
+      <%= link_to @back_url, class: "block py-1.5" do %>
+        <%= lucide_icon("arrow-left", class: "transition text-gray-900 hover:text-gray-700 active:scale-95 stroke-[2.5]")%>
+      <% end %>
+    </div>
+
+    <%# タイトル %>
+    <div class="flex-1 text-center text-xl font-bold text-gray-800 truncate px-2">
+      累計地図
+    </div>
+
+    <%# 右側の「…」ボタン %>
+    <div class="flex-none">
+      <div class="w-8"></div>
+    </div>
+  </header>
+
+  <%# --- マップ部分 --- %>
+  <div class="relative flex-1 min-h-0 w-full">
+    <div id="history-map"
+      data-controller="history-map"
+      class="absolute inset-0 h-full w-full"
+      data-maptiler-key="<%= Rails.application.credentials.dig(:maptiler, :api_key) %>"
+      data-history-map-longitude-value="<%= @first_footprint&.longitude %>"
+      data-history-map-latitude-value="<%= @first_footprint&.latitude %>"
+      data-history-map-visited-geohashes-value="<%= json_escape(@visited_geohashes&.to_json) %>"
+    >
+      <div class="fixed bg-white w-full h-[130%] -bottom-[30%] inset-0 z-20 transition-transform duration-[2000ms] opacity-100 pointer-events-none ease-in-out
+                  [mask-image:linear-gradient(to_bottom,black_80%,transparent)]"
+                  data-history-map-target="mapOverlay"></div>
+    </div>
+  </div>
+</div>

--- a/app/views/trips/index.html.erb
+++ b/app/views/trips/index.html.erb
@@ -9,7 +9,7 @@
     </div>
 
     <%# 右側の「累計地図」ボタン %>
-    <%= link_to "累計地図", "#", class: "absolute right-4 rounded-full bg-orange-400 px-4 py-1.5 text-sm font-bold text-white shadow transition hover:bg-orange-500 active:scale-95" %>
+    <%= link_to "累計地図", my_map_path, class: "absolute right-4 rounded-full bg-orange-400 px-4 py-1.5 text-sm font-bold text-white shadow transition hover:bg-orange-500 active:scale-95" %>
   </header>
 
   <%# --- メインリスト部分 --- %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,6 +43,7 @@ Rails.application.routes.draw do
 
   get "privacy_policy", to: "pages#privacy_policy"
   get "terms", to: "pages#terms"
+  resource :my_map, only: :show
 
   namespace :api do
     namespace :v1 do

--- a/test/controllers/my_maps_controller_test.rb
+++ b/test/controllers/my_maps_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class MyMapsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## issue
- close: #25 
- 関連issue:
  - #26 

## 実装内容
- 累計地図を表示するMyMapcontrollerを作成
- showアクションで累計地図を表示するデータを取得するよう実装
- show.html.erbを作成し、累計地図表示機能を実装
- history_map_controller.jsのロジックを書き換えて、普通の地図履歴の時も、累計地図の時もどちらにも対応して表示できるように変更
- ジオハッシュの計算をクライアント側で計算するようにjs側とrailsのコードを書き換える

## issueとの差分
- コントローラー名の変更
- API機能は使わずに、コントローラーを作成して表示するように変更

## 動作確認方法
- ブラウザで実際に確認

## 補足
- 初期のカメラ位置をどこにすれば良いのか後で詰める
