### PR TITLE
投稿詳細表示機能実装

### DIFF
--- a/app/assets/stylesheets/my_style.css
+++ b/app/assets/stylesheets/my_style.css
@@ -51,10 +51,7 @@
   animation: none !important;
 }
 
-
-/* ==========================================
-    究極のMac仕様スクロールバー
-========================================== */
+/* スクロールバー設定 */
 .overflow-y-auto::-webkit-scrollbar,
 .overflow-x-auto::-webkit-scrollbar {
   width: 12px;
@@ -66,24 +63,21 @@
   background: transparent !important;
 }
 
-/* 🚨 1. 普段は【完全に透明】（画面に乗っても出ない） */
 .overflow-y-auto::-webkit-scrollbar-thumb,
 .overflow-x-auto::-webkit-scrollbar-thumb {
   background-color: transparent;
   border-radius: 9999px;
-  border: 4px solid transparent; 
+  border: 4px solid transparent;
   background-clip: content-box;
 }
 
-/* 🚨 2. 「スクロール中（JSが付与するクラス）」または「バー自体をホバーした時」だけ出現！ */
 .overflow-y-auto.is-scrolling::-webkit-scrollbar-thumb,
 .overflow-x-auto.is-scrolling::-webkit-scrollbar-thumb,
 .overflow-y-auto::-webkit-scrollbar-thumb:hover,
 .overflow-x-auto::-webkit-scrollbar-thumb:hover {
-  background-color: rgba(75, 85, 99, 0.5); /* スッ…と上品に出現 */
+  background-color: rgba(75, 85, 99, 0.5);
 }
 
-/* 🚨 3. バーをドラッグ（クリック）している最中はさらに濃くする */
 .overflow-y-auto::-webkit-scrollbar-thumb:active,
 .overflow-x-auto::-webkit-scrollbar-thumb:active {
   background-color: rgba(55, 65, 81, 0.8) !important;

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -36,7 +36,7 @@ class PostsController < ApplicationController
     respond_modal
   end
 
-  def show
+  def preview
     @post = Post.includes(:trip, user: { avatar_attachment: :blob }).with_attached_images.find_by(public_uid: params[:id])
 
     if @post.nil?
@@ -48,6 +48,10 @@ class PostsController < ApplicationController
     else
       respond_modal("shared/flash_message", flash_message: { alert: "この投稿は表示できません" })
     end
+  end
+
+  def show
+    preview
   end
 
   private

--- a/app/javascript/controllers/base_map_controller.js
+++ b/app/javascript/controllers/base_map_controller.js
@@ -228,7 +228,7 @@ export default class extends Controller {
 
     const el = marker.getElement();
 
-    el.setAttribute("data-action", `click->${this.identifier}#openPostDetails`);
+    el.setAttribute("data-action", `click->${this.identifier}#openPostPreview`);
 
     el.setAttribute("data-post-uid", post.public_uid);
     el.setAttribute("data-post-lng", post.longitude);
@@ -237,7 +237,7 @@ export default class extends Controller {
     this.markers.push(marker);
   }
 
-  openPostDetails(event) {
+  openPostPreview(event) {
     const el = event.currentTarget;
 
     const uid = el.getAttribute("data-post-uid");
@@ -256,7 +256,7 @@ export default class extends Controller {
       },
     });
 
-    get(`/posts/${uid}`, { responseKind: "turbo-stream" });
+    get(`/posts/${uid}/preview`, { responseKind: "turbo-stream" });
   }
 
   // 霧の初期化

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -20,6 +20,7 @@ class Post < ApplicationRecord
 
   # バリデーション定義
   validates :user_id, :latitude, :longitude, :visibility, :visited_at, presence: true
+  validate :body_or_images_presence
 
   # アソシエーション定義
   belongs_to :user
@@ -34,5 +35,13 @@ class Post < ApplicationRecord
 
   def to_param
     public_uid
+  end
+
+  private
+
+  def body_or_images_presence
+    if body.blank? && images.blank?
+      errors.add(:base, "本文または画像のどちらかが必須です")
+    end
   end
 end

--- a/app/views/posts/preview.turbo_stream.erb
+++ b/app/views/posts/preview.turbo_stream.erb
@@ -1,0 +1,95 @@
+<%= turbo_stream.update "bottom-sheet-container" do %>
+  <div class="fixed inset-0 h-full pointer-events-none opacity-0 w-full z-40 flex flex-col justify-end transition-all duration-300" data-controller="bottom-sheet">
+
+    <%# --- バックドロップ --- %>
+    <div class="absolute inset-0 bg-black/50 z-0 pointer-events-auto" data-bottom-sheet-target="bottomSheetBackdrop" data-action="click->bottom-sheet#close"></div>
+
+    <%# --- ボトムシート全体 --- %>
+    <div data-bottom-sheet-target="bottomSheetBox"
+          class="relative inset-x-0 bottom-0 z-10 flex flex-col w-full max-h-[60vh] rounded-t-3xl bg-[#FFFBE6] pb-11 pt-8 shadow-[0_-5px_20px_rgba(0,0,0,0.1)] transition-transform translate-y-full duration-300 pointer-events-auto">
+
+      <%# --- 右上のバツボタン --- %>
+      <button class="absolute right-1 top-1 sm:right-1 sm:top-1 h-10 w-10 flex items-center justify-center leading-none bg-gray-500/50 hover:bg-gray-600/60 text-white rounded-full z-30 transition" data-action="click->bottom-sheet#close">
+        <%= lucide_icon('x', class: "w-6 h-6") %>
+      </button>
+
+      <%# --- ドラッグハンドル --- %>
+      <div class="absolute mx-auto mb-2 h-1.5 w-12 shrink-0 rounded-full bg-gray-300 top-3 left-1/2 -transrate-x-1/2"></div>
+
+      <%# --- ヘッダー --- %>
+      <div class="modal-header shrink-0 z-20 w-full px-2 sm:px-4">
+        <div class="flex items-center justify-between border-b border-orange-200/60 pb-3">
+          <div class="flex items-center gap-3">
+            <% if @post.user.avatar.attached? %>
+              <%= image_tag @post.user.avatar, class: "w-10 h-10 object-cover rounded-full shadow-sm" %>
+            <% else %>
+              <div class="w-10 h-10 bg-orange-400 rounded-full flex items-center justify-center shadow-sm">
+                <%= lucide_icon('user-round', class: "w-6 h-6 text-white") %>
+              </div>
+            <% end %>
+            <div class="font-bold text-gray-800 text-base"><%= @post.user.nickname %></div>
+          </div>
+          <div class="text-sm text-gray-500 font-medium">
+            <%= @post.visited_at&.strftime("%Y/%m/%d %H:%M") %>
+          </div>
+        </div>
+      </div>
+
+      <%# --- メインコンテンツ--- %>
+      <%= link_to post_path(@post),
+                  class: "w-full h-full",
+                  data: { turbo_stream: true, bottom_sheet_target: "bottomSheetBox" } do %>
+
+        <div class="flex-1 min-h-0 flex flex-col px-4 pb-4 gap-3 w-full max-w-xl mx-auto">
+
+          <%# 本文 %>
+          <% if @post.body.present? %>
+            <% text_classes = @post.images.attached? ? "line-clamp-3 shrink-0 pt-3" : "pt-3" %>
+
+            <div class="text-gray-700 text-base whitespace-pre-wrap leading-tight font-medium <%= text_classes %>"><%= @post.body %></div>
+          <% end %>
+
+          <%# 画像エリア %>
+          <% if @post.images.attached? %>
+            <div class="w-full shrink-0 pt-3">
+
+              <% image_count = @post.images.size %>
+
+              <%# --- 画像が1枚だけの場合 --- %>
+              <% if image_count == 1 %>
+                <div class="w-full flex justify-center items-center">
+                  <%= image_tag @post.images.first,
+                                loading: "lazy",
+                                class: "max-w-full h-auto max-h-[40vh] object-contain rounded-xl shadow-sm" %>
+                </div>
+
+              <%# --- 画像が複数ある場合 --- %>
+              <% else %>
+                <div class="grid grid-cols-2 gap-1 w-full rounded-xl overflow-hidden">
+                  <% @post.images.first(4).each_with_index do |image, index| %>
+                    <div class="relative w-full aspect-[4/3] max-h-[18vh] bg-gray-200" style="container-type: inline-size;">
+                      <%= image_tag image, loading: "lazy",
+                            class: "absolute inset-0 w-full h-full object-cover" %>
+
+                      <% if index == 3 && image_count > 4 %>
+                        <div class="absolute inset-0 bg-black/60 flex items-center justify-center">
+                          <span class="text-white font-bold tracking-wider text-center" style="font-size: 25cqw;">
+                            + <%= image_count - 4 %>
+                          </span>
+                        </div>
+                      <% end %>
+                    </div>
+                  <% end %>
+                </div>
+              <% end %>
+
+            </div>
+          <% end %>
+
+        </div>
+
+      <% end %>
+
+    </div>
+  </div>
+<% end %>

--- a/app/views/posts/show.turbo_stream.erb
+++ b/app/views/posts/show.turbo_stream.erb
@@ -1,107 +1,64 @@
-<%= turbo_stream.update "bottom-sheet-container" do %>
-  <div class="fixed inset-0 h-full pointer-events-none opacity-0 w-full z-40 flex flex-col justify-end transition-all duration-300" data-controller="bottom-sheet">
+<%= turbo_stream.append "modal-container" do %>
+  <div class="fixed inset-0 h-full pointer-events-none w-full z-40 flex justify-center items-stretch sm:items-center opacity-0 transition-all duration-300 p-0 sm:p-4 lg:p-10" data-controller="modal">
 
     <%# --- バックドロップ --- %>
-    <div class="absolute inset-0 bg-black/50 z-0 pointer-events-auto" data-bottom-sheet-target="bottomSheetBackdrop" data-action="click->bottom-sheet#close"></div>
+    <div class="modal-backdrop absolute inset-0 bg-black/50 z-0 pointer-events-auto" data-modal-target="modalBackdrop" data-action="click->modal#close"></div>
 
-    <%# --- ボトムシート全体 --- %>
-    <div class="relative inset-x-0 bottom-0 z-10 flex flex-col w-full max-h-[60vh] rounded-t-3xl bg-[#FFFBE6] pb-11 pt-3 shadow-[0_-5px_20px_rgba(0,0,0,0.1)] transition-transform translate-y-full duration-300 pointer-events-auto" data-bottom-sheet-target="bottomSheetBox">
+    <%# モーダル枠 %>
+    <div class="relative w-full pointer-events-auto modal-box h-full sm:h-auto bg-[#FFFBE6] max-w-none sm:max-w-5xl max-h-none sm:max-h-[90vh] pt-1 sm:pt-2 pb-6 px-0 sm:px-0  rounded-none sm:rounded-xl gap-4 flex flex-col items-center z-10 transition-all duration-500 ease-out translate-y-40 opacity-0 overflow-hidden" data-modal-target="modalBox">
 
-      <%# --- ドラッグハンドル --- %>
-      <div class="mx-auto mb-2 h-1.5 w-12 shrink-0 rounded-full bg-gray-300"></div>
+      <%# --- 右上のバツボタン --- %>
+      <button class="absolute right-1 top-1 sm:right-1 sm:top-1 h-10 w-10 flex items-center justify-center leading-none bg-gray-500/50 hover:bg-gray-600/60 text-white rounded-full z-30 transition" data-action="click->modal#close">
+        <%= lucide_icon('x', class: "w-6 h-6") %>
+      </button>
 
       <%# --- ヘッダー --- %>
-      <div class="flex items-center justify-between px-4 pb-2 border-b border-gray-100 shrink-0">
-
-        <%# 左側エリア %>
-        <div class="flex items-center gap-2">
-
-          <%# ユーザー %>
+      <div class="modal-header shrink-0 z-20 w-full px-2 sm:px-4 pt-2">
+        <div class="flex items-center justify-between border-b border-orange-200/60 pb-3">
           <div class="flex items-center gap-3">
-
-            <%# アイコン %>
             <% if @post.user.avatar.attached? %>
-              <div class="w-10 h-10 rounded-full overflow-hidden shrink-0 flex items-center justify-center shadow-md">
-                <%= image_tag @post.user.avatar, class: "w-full h-full object-cover rounded-full" %>
-              </div>
+              <%= image_tag @post.user.avatar, class: "w-10 h-10 object-cover rounded-full shadow-sm" %>
             <% else %>
-              <div class="w-10 h-10 bg-orange-400 rounded-full overflow-hidden shrink-0 flex items-center justify-center shadow-md">
-                <%= lucide_icon('user-round', class: "m-1 w-full h-full text-white") %>
+              <div class="w-10 h-10 bg-orange-400 rounded-full flex items-center justify-center shadow-sm">
+                <%= lucide_icon('user-round', class: "w-6 h-6 text-white") %>
               </div>
             <% end %>
-
-            <%# ユーザー名 %>
-            <div class="font-bold text-gray-800 text-sm">
-              <%= @post.user.nickname %>
-            </div>
-
+            <div class="font-bold text-gray-800 text-base"><%= @post.user.nickname %></div>
           </div>
-
-        </div>
-
-        <%# 右側ボタンエリア %>
-        <div class="flex items-center gap-2">
-
-          <%# バツボタン %>
-          <button type="button" class="p-2 text-gray-500 hover:bg-gray-200 bg-gray-100 rounded-full transition active:scale-95" data-action="click->bottom-sheet#close">
-            <%= lucide_icon('x', class: "w-5 h-5") %>
-          </button>
-
+          <div class="text-sm text-gray-500 font-medium pr-10">
+            <%= @post.visited_at&.strftime("%Y/%m/%d %H:%M") %>
+          </div>
         </div>
       </div>
 
-      <%# --- メインコンテンツ--- %>
-      <div class="flex-1 min-h-0 flex flex-col px-4 pb-4 gap-3 w-full max-w-xl mx-auto">
-
-        <%# 日付 %>
-        <div class="text-gray-700 text-md font-bold leading-none shrink-0"><%= @post.visited_at&.strftime("%Y/%m/%d %H:%M") %></div>
+      <%# --- モーダルの本文と画像枠 --- %>
+      <div class="modal-body flex-1 min-h-0 w-full px-2 sm:px-4 z-20 overflow-y-auto">
 
         <%# 本文 %>
         <% if @post.body.present? %>
-          <% text_classes = @post.images.attached? ? "line-clamp-3 shrink-0" : "" %>
-
-          <div class="text-gray-700 text-base whitespace-pre-wrap leading-tight font-medium <%= text_classes %>"><%= @post.body %></div>
+          <div class="text-gray-800 text-base sm:text-lg whitespace-pre-wrap leading-relaxed mb-6"><%= @post.body %></div>
         <% end %>
 
         <%# 画像エリア %>
         <% if @post.images.attached? %>
-          <div class="w-full shrink-0">
+          <div class="w-full">
 
-            <% image_count = @post.images.size %>
+            <div class="columns-2 sm:columns-3 lg:columns-4 gap-3 sm:gap-4 w-full">
+              <% @post.images.each do |image| %>
 
-            <%# --- 画像が1枚だけの場合 --- %>
-            <% if image_count == 1 %>
-              <div class="w-full flex justify-center items-center">
-                <%= image_tag @post.images.first,
-                              loading: "lazy",
-                              class: "max-w-full h-auto max-h-[40vh] object-contain rounded-xl shadow-sm" %>
-              </div>
+                <div class="break-inside-avoid mb-3 sm:mb-4 w-full">
+                  <%= link_to url_for(image), target: "_blank", rel: "noopener" do %>
+                    <%= image_tag image, loading: "lazy", class: "w-full h-auto object-cover rounded-xl shadow-sm border border-orange-200/50 hover:brightness-50 transition duration-300 cursor-pointer" %>
+                  <% end %>
+                </div>
 
-            <%# --- 画像が複数ある場合 --- %>
-            <% else %>
-              <div class="grid grid-cols-2 gap-1 w-full rounded-xl overflow-hidden">
-                <% @post.images.first(4).each_with_index do |image, index| %>
-                  <div class="relative w-full aspect-[4/3] max-h-[18vh] bg-gray-200" style="container-type: inline-size;">
-                    <%= image_tag image, loading: "lazy",
-                          class: "absolute inset-0 w-full h-full object-cover" %>
-
-                    <% if index == 3 && image_count > 4 %>
-                      <div class="absolute inset-0 bg-black/60 flex items-center justify-center">
-                        <span class="text-white font-bold tracking-wider text-center" style="font-size: 25cqw;">
-                          + <%= image_count - 4 %>
-                        </span>
-                      </div>
-                    <% end %>
-                  </div>
-                <% end %>
-              </div>
-            <% end %>
+              <% end %>
+            </div>
 
           </div>
         <% end %>
 
       </div>
-
     </div>
   </div>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,7 +44,11 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :posts, only: %i[ show ]
+  resources :posts, only: %i[ show ] do
+    member do
+      get :preview
+    end
+  end
 
   get "select_position", to: "posts#select_position"
 


### PR DESCRIPTION
## issue
- close: #131 
- 関連issue:
  - #127 

## 実装内容
- posts#showアクションをpreviewに変更
- 対応するビューの名前を修正。showをpreviewに
- ルーティングを修正してshowをpreviewに
- ビューのリンクの修正。posts#showへのリンクをposts#previewに
- posts#showアクションを作成
- 詳細を全画面表示で表示するビューを作成
- ルーティングの設定して、showで詳細の全画面が表示されるように
- posts#previewのビューファイルに詳細画面表示がされるようにリンクを設定
- postモデルにbodyとimagesが空の場合は投稿ができないようにバリデーションを追加

## issueとの差分
- postモデルへのバリデーション部分を追加

## 動作確認方法
- ブラウザで想定通りの動きとなっているのか確認

## 補足
- 詳細画像での画像の最大化表示が、画像そのものへのリンクとなっているので、後で表示の方法を変更する
