### PR TITLE
post#destroy実装

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -58,6 +58,32 @@ class PostsController < ApplicationController
     preview
   end
 
+  def confirm_destroy
+    @post = current_user&.posts&.find_by(public_uid: params[:id])
+
+    unless @post
+      respond_modal("shared/flash_message", flash_message: { alert: "削除できません" })
+      return
+    end
+
+    respond_modal
+  end
+
+  def destroy
+    @post = current_user.posts.find_by(public_uid: params[:id])
+
+    if @post.nil?
+      respond_modal("shared/flash_message", flash_message: { alert: "この記録は削除できません" })
+      return
+    end
+
+    if @post.destroy
+      respond_modal(flash_message: { alert: "記録を削除しました" })
+    else
+      respond_modal("shared/flash_and_error", locals: { object: @post }, flash_message: { alert: "記録の削除に失敗しました" })
+    end
+  end
+
   private
 
   def post_params

--- a/app/javascript/controllers/base_map_controller.js
+++ b/app/javascript/controllers/base_map_controller.js
@@ -23,7 +23,7 @@ export default class extends Controller {
     this.mapInitEnd = false; // 初期化終了フラグ
     this.clearMapOverlayEnd = false; // 初期のマップオーバーレイクリアフラグ
     this.isPostModeActive = false; // 投稿モードの状態管理変数を定義
-    this.markers = []; // マーカーを保存する配列
+    this.markers = {}; // マーカーを保存するオブジェクト
 
     // 前のが残っていた時に備えて最初に消してからアボートコントローラーをセット
     this.ac?.abort();
@@ -207,6 +207,11 @@ export default class extends Controller {
     })
   }
 
+  removeMarker(postUid){
+    this.markers[postUid]?.remove();
+    delete this.markers[postUid];
+  }
+
   // appendMarkerTargetが接続されたときにマップにマーカーを追加
   appendMarkerTargetConnected(element){
     const post = JSON.parse(element.dataset.post)
@@ -234,7 +239,7 @@ export default class extends Controller {
     el.setAttribute("data-post-lng", post.longitude);
     el.setAttribute("data-post-lat", post.latitude);
 
-    this.markers.push(marker);
+    this.markers[post.public_uid] = marker;
   }
 
   openPostPreview(event) {

--- a/app/javascript/controllers/dropdown_controller.js
+++ b/app/javascript/controllers/dropdown_controller.js
@@ -1,0 +1,27 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="dropdown"
+export default class extends Controller {
+  static values = { postUrl: String }
+  connect() {
+  }
+
+  toggle(event){
+    // すでにメニューがある場合は削除
+    const existingMenu = event.currentTarget.parentNode.querySelector('.my-dropdown-menu');
+    if (existingMenu) {
+      existingMenu.remove();
+      return;
+    }
+
+    const url = this.postUrlValue;
+    const div = document.createElement("div");
+    div.className = "my-dropdown-menu absolute top-full right-0 mt-2 w-20 bg-white shadow-lg rounded-md border border-gray-400 z-50 flex flex-col text-black";
+    div.innerHTML = `
+      <a href="" class="px-2 py-1 hover:bg-gray-100 rounded">編集</a>
+      <a href="${url}" data-turbo-stream="true" class="px-2 py-1 hover:bg-gray-100 rounded text-red-500">削除</a>
+    `;
+
+    event.currentTarget.appendChild(div);
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -19,6 +19,9 @@ application.register("copy", CopyController)
 import DispatchController from "./dispatch_controller"
 application.register("dispatch", DispatchController)
 
+import DropdownController from "./dropdown_controller"
+application.register("dropdown", DropdownController)
+
 import ErrorController from "./error_controller"
 application.register("error", ErrorController)
 

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -645,10 +645,10 @@ export default class extends BaseMapController {
     console.log(this.visitedGeohashes)
     this.executeFogClearing(true);
 
-    this.markers.forEach(marker => {
+    Object.values(this.markers).forEach(marker => {
       marker.remove();
     });
-    this.markers = [];
+    this.markers = {};
   }
 
   resetFogData() {

--- a/app/javascript/controllers/ui_controller.js
+++ b/app/javascript/controllers/ui_controller.js
@@ -335,4 +335,15 @@ export default class extends Controller {
       this.mapOutlet.geolocateTrigger();
     }
   }
+
+  removeMarker(event){
+    const postUuid = event.currentTarget.dataset.postUuid;
+
+    if(this.hasMapOutlet){
+      this.mapOutlet.removeMarker(postUuid);
+    }
+    if(this.hasHistoryMapOutlet){
+      this.historyMapOutlet.removeMarker(postUuid);
+    }
+  }
 }

--- a/app/views/posts/confirm_destroy.turbo_stream.erb
+++ b/app/views/posts/confirm_destroy.turbo_stream.erb
@@ -1,0 +1,47 @@
+<%= turbo_stream.append "modal-container" do %>
+
+  <%# 全体の枠 %>
+  <div class="fixed inset-0 h-full pointer-events-none w-full z-40 flex justify-center items-center opacity-0 transition-all duration-300 p-10" data-controller="modal">
+
+    <%# バックドロップ %>
+    <div class="modal-backdrop absolute inset-0 bg-black/50 z-0 pointer-events-auto" data-modal-target="modalBackdrop" data-action="click->modal#close"></div>
+
+      <%# モーダル枠 %>
+      <div class="relative max-w-sm pointer-events-auto modal-box max-h-[90dvh] w-full bg-orange-100 p-4 gap-3 flex flex-col items-center rounded-xl z-10 transition-all duration-500 ease-out translate-y-40 opacity-0 overflow-hidden" data-modal-target="modalBox">
+        <button class="absolute right-2 top-2 h-6 w-6 flex items-center justify-center leading-none bg-gray-500/50 rounded-full z-30" data-action="click->modal#close">
+          <%= lucide_icon('x') %>
+        </button>
+
+        <div class="modal-header shrink-0 z-20">
+          <div class="text-lg font-bold">
+            この記録を削除しますか？
+          </div>
+        </div>
+
+        <%# モーダル本文 %>
+        <div class="modal-body flex-1 min-h-0 px-4 z-20">
+          <div class="flex flex-col items-center gap-4">
+            <div class="text-gray-400">
+              ※削除すると、二度と元に戻せません。
+            </div>
+          </div>
+        </div>
+
+        <div class="modal-footer shrink-0 flex justify-between z-20 w-full px-5">
+          <button type="submit" name="decision" class="btn" data-action="click->modal#close">
+            <div class="text-gray-500">
+              キャンセル
+            </div>
+          </button>
+          <%= button_to "削除する", post_path(@post),
+                method: :delete,
+                class: "text-red-500",
+                data: { turbo_stream: true, action: "click->modal#close click->ui#removeMarker", post_uuid: @post.public_uid },
+                form: { class: "contents" } %>
+        </div>
+
+    </div>
+
+  </div>
+
+<% end %>

--- a/app/views/posts/destroy.turbo_stream.erb
+++ b/app/views/posts/destroy.turbo_stream.erb
@@ -1,0 +1,2 @@
+<%= turbo_stream.update "bottom-sheet-container", "" %>
+<%= turbo_stream.update "modal-container", "" %>

--- a/app/views/posts/preview.turbo_stream.erb
+++ b/app/views/posts/preview.turbo_stream.erb
@@ -6,12 +6,26 @@
 
     <%# --- ボトムシート全体 --- %>
     <div data-bottom-sheet-target="bottomSheetBox"
-          class="relative inset-x-0 bottom-0 z-10 flex flex-col w-full max-h-[60vh] rounded-t-3xl bg-[#FFFBE6] pb-11 pt-8 shadow-[0_-5px_20px_rgba(0,0,0,0.1)] transition-transform translate-y-full duration-300 pointer-events-auto">
+          class="relative inset-x-0 bottom-0 z-10 flex flex-col w-full max-h-[60dvh] rounded-t-3xl bg-[#FFFBE6] pb-11 pt-8 shadow-[0_-5px_20px_rgba(0,0,0,0.1)] transition-transform translate-y-full duration-300 pointer-events-auto">
 
-      <%# --- 右上のバツボタン --- %>
-      <button class="absolute right-1 top-1 sm:right-1 sm:top-1 h-10 w-10 flex items-center justify-center leading-none bg-gray-500/50 hover:bg-gray-600/60 text-white rounded-full z-30 transition" data-action="click->bottom-sheet#close">
-        <%= lucide_icon('x', class: "w-6 h-6") %>
-      </button>
+      <%# --- 右上の枠 --- %>
+      <div class="absolute right-1 top-1 z-30 flex items-center gap-2">
+
+        <%# --- 三点リーダボタン --- %>
+        <div class="relative" data-controller="dropdown" data-dropdown-post-url-value="<%= confirm_destroy_post_path(@post) %>">
+          <button type="button"
+                  class="h-10 w-10 flex items-center justify-center bg-gray-500/50 hover:bg-gray-600/60 text-white rounded-full transition"
+                  data-action="click->dropdown#toggle">
+            <%= lucide_icon('ellipsis-vertical', class: "w-6 h-6") %>
+          </button>
+        </div>
+
+        <%# --- バツボタン --- %>
+        <button class="h-10 w-10 flex items-center justify-center bg-gray-500/50 hover:bg-gray-600/60 text-white rounded-full transition" data-action="click->bottom-sheet#close">
+          <%= lucide_icon('x', class: "w-6 h-6") %>
+        </button>
+
+      </div>
 
       <%# --- ドラッグハンドル --- %>
       <div class="absolute mx-auto mb-2 h-1.5 w-12 shrink-0 rounded-full bg-gray-300 top-3 left-1/2 -transrate-x-1/2"></div>

--- a/app/views/posts/show.turbo_stream.erb
+++ b/app/views/posts/show.turbo_stream.erb
@@ -7,10 +7,24 @@
     <%# モーダル枠 %>
     <div class="relative w-full pointer-events-auto modal-box h-full sm:h-auto bg-[#FFFBE6] max-w-none sm:max-w-5xl max-h-none sm:max-h-[90vh] pt-1 sm:pt-2 pb-6 px-0 sm:px-0  rounded-none sm:rounded-xl gap-4 flex flex-col items-center z-10 transition-all duration-500 ease-out translate-y-40 opacity-0 overflow-hidden" data-modal-target="modalBox">
 
-      <%# --- 右上のバツボタン --- %>
-      <button class="absolute right-1 top-1 sm:right-1 sm:top-1 h-10 w-10 flex items-center justify-center leading-none bg-gray-500/50 hover:bg-gray-600/60 text-white rounded-full z-30 transition" data-action="click->modal#close">
-        <%= lucide_icon('x', class: "w-6 h-6") %>
-      </button>
+      <%# --- 右上の枠 --- %>
+      <div class="absolute right-1 top-1 z-30 flex items-center gap-2">
+
+        <%# --- 三点リーダボタン --- %>
+        <div class="relative" data-controller="dropdown" data-dropdown-post-url-value="<%= confirm_destroy_post_path(@post) %>">
+          <button type="button"
+                  class="h-10 w-10 flex items-center justify-center bg-gray-500/50 hover:bg-gray-600/60 text-white rounded-full transition"
+                  data-action="click->dropdown#toggle">
+            <%= lucide_icon('ellipsis-vertical', class: "w-6 h-6") %>
+          </button>
+        </div>
+
+        <%# --- バツボタン --- %>
+        <button class="h-10 w-10 flex items-center justify-center bg-gray-500/50 hover:bg-gray-600/60 text-white rounded-full transition" data-action="click->bottom-sheet#close">
+          <%= lucide_icon('x', class: "w-6 h-6") %>
+        </button>
+
+      </div>
 
       <%# --- ヘッダー --- %>
       <div class="modal-header shrink-0 z-20 w-full px-2 sm:px-4 pt-2">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,10 +44,11 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :posts, only: %i[ show ] do
+  resources :posts, only: %i[ show destroy ] do
     member do
       get :preview
       get :image_viewer
+      get :confirm_destroy
     end
   end
 


### PR DESCRIPTION
## issue
- close: #135 

## 実装内容
- 投稿を削除するリンクをpreviewとshowに追加
- posts#confirm_destroyを追加
- posts#destroyを追加
- posts#confirm_destroyのルーティングを設定
- posts#destroyのルーティングを設定
- 削除後に画面を更新してマーカーの表示を消すように設定

## issueとの差分
- なし

## 動作確認方法
- ブラウザで実際にpostが削除されるのか見た目で確認
- ログでpostのデータが削除されているのか確認

## 補足
- 削除のドロップダウンメニューを、メニュー以外の部分をクリックしたときに閉じるように後で変更
