### PR TITLE
posts#createでのvisited_atの設定可能に

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -87,7 +87,7 @@ class PostsController < ApplicationController
   private
 
   def post_params
-    params.require(:post).permit(:body, :latitude, :longitude, images: [])
+    params.require(:post).permit(:body, :latitude, :longitude, :visited_at, images: [])
   end
 
   def set_trip

--- a/app/javascript/controllers/base_map_controller.js
+++ b/app/javascript/controllers/base_map_controller.js
@@ -248,17 +248,15 @@ export default class extends Controller {
     const uid = el.getAttribute("data-post-uid");
     const lng = parseFloat(el.getAttribute("data-post-lng"));
     const lat = parseFloat(el.getAttribute("data-post-lat"));
-    const halfHeight = window.innerHeight / 2;
+    const moveHeight = window.innerHeight / 4;
+
+    const point = this.map.project([lng, lat]); // マーカーの緯度経度を画面上のピクセル座標に変換
+    point.y += moveHeight; // yを移動
+    const newCenter = this.map.unproject(point); // ずらしたピクセル座標を緯度軽度に変換
 
     this.map.easeTo({
-      center: [lng, lat],
+      center: newCenter,
       duration: 500,
-      padding: {
-        top: 0,
-        bottom: halfHeight,
-        left: 0,
-        right: 0
-      },
     });
 
     get(`/posts/${uid}/preview`, { responseKind: "turbo-stream" });

--- a/app/javascript/controllers/image_viewer_controller.js
+++ b/app/javascript/controllers/image_viewer_controller.js
@@ -16,7 +16,7 @@ export default class extends Controller {
 
     // 画面サイズによって、倍率を変更
     const isMobile = window.matchMedia('(max-width: 640px)').matches;
-    const zoomMaxRatio = isMobile ? 20 : 3;
+    const zoomMaxRatio = isMobile ? 10 : 3;
 
     const paginationEl = this.element.querySelector('.swiper-pagination')
     const nextEl = this.element.querySelector('.custom-button-next')

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -21,6 +21,7 @@ class Post < ApplicationRecord
   # バリデーション定義
   validates :user_id, :latitude, :longitude, :visibility, :visited_at, presence: true
   validate :body_or_images_presence
+  validate :visited_at_cannot_be_in_the_future
 
   # アソシエーション定義
   belongs_to :user
@@ -42,6 +43,14 @@ class Post < ApplicationRecord
   def body_or_images_presence
     if body.blank? && images.blank?
       errors.add(:base, "本文または画像のどちらかが必須です")
+    end
+  end
+
+  def visited_at_cannot_be_in_the_future
+    return if visited_at.blank?
+
+    if visited_at > Time.current
+      errors.add(:visited_at, "は未来の日時に設定できません")
     end
   end
 end

--- a/app/views/bottom_sheets/_bottom_sheet.html.erb
+++ b/app/views/bottom_sheets/_bottom_sheet.html.erb
@@ -6,7 +6,7 @@
   <%# --- ボトムシート全体 --- %>
   <div class="fixed inset-x-0 bottom-0 z-10 rounded-t-[2rem] bg-[#FFFBE6] pb-11 pt-4 shadow-[0_-5px_20px_rgba(0,0,0,0.1)] transition-transform translate-y-full duration-300 pointer-events-auto" data-bottom-sheet-target="bottomSheetBox">
 
-    <%# --- ドラッグハンドル（つまみ） --- %>
+    <%# --- ドラッグハンドル --- %>
     <div class="mx-auto mb-6 h-1.5 w-12 rounded-full bg-gray-400"></div>
 
     <%# --- タイトル --- %>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -25,6 +25,19 @@
   <%# --- メイン --- %>
   <div class="flex-1 overflow-y-auto p-4 flex flex-col gap-6">
 
+    <%# 訪問日時入力エリア %>
+    <div class="shrink-0 w-full border-b border-gray-200 pb-2">
+      <%= f.label :visited_at, class: "flex items-center gap-4 w-fit" do %>
+        <span class="font-bold text-gray-700 whitespace-nowrap select-none">訪問日時</span>
+        <%= f.datetime_field :visited_at,
+            value: f.object.visited_at&.strftime('%Y-%m-%dT%H:%M'),
+            max: Time.current.strftime('%Y-%m-%dT%H:%M'),
+            class: "w-auto border-none outline-none focus:ring-0 text-lg leading-relaxed text-gray-700 bg-transparent",
+            style: "box-shadow: none;"
+        %>
+      <% end %>
+    </div>
+
     <%# テキスト入力エリア %>
     <div class="flex-1 min-h-[40vh] border border-gray-400 flex">
       <%= f.text_area :body,

--- a/app/views/posts/_new.html.erb
+++ b/app/views/posts/_new.html.erb
@@ -3,7 +3,7 @@
 
   <div class="absolute inset-0 bg-black/80 backdrop-blur-sm" data-action="click->posts#close"></div>
   <%# モーダルコンテナ %>
-  <div class="bg-white z-40 w-full h-full md:h-auto md:max-h-[90vh] md:w-full md:max-w-lg md:rounded-2xl shadow-2xl overflow-hidden flex flex-col">
+  <div class="bg-[#FFFBE6] z-40 w-full h-full md:h-auto md:max-h-[90vh] md:w-full md:max-w-lg md:rounded-2xl shadow-2xl overflow-hidden flex flex-col">
 
     <%# フォームの中身を呼ぶ %>
     <%= render "form", post: @post %>

--- a/app/views/posts/confirm_destroy.turbo_stream.erb
+++ b/app/views/posts/confirm_destroy.turbo_stream.erb
@@ -7,7 +7,7 @@
     <div class="modal-backdrop absolute inset-0 bg-black/50 z-0 pointer-events-auto" data-modal-target="modalBackdrop" data-action="click->modal#close"></div>
 
       <%# モーダル枠 %>
-      <div class="relative max-w-sm pointer-events-auto modal-box max-h-[90dvh] w-full bg-orange-100 p-4 gap-3 flex flex-col items-center rounded-xl z-10 transition-all duration-500 ease-out translate-y-40 opacity-0 overflow-hidden" data-modal-target="modalBox">
+      <div class="relative max-w-sm pointer-events-auto modal-box max-h-[90vh] w-full bg-orange-100 p-4 gap-3 flex flex-col items-center rounded-xl z-10 transition-all duration-500 ease-out translate-y-40 opacity-0 overflow-hidden" data-modal-target="modalBox">
         <button class="absolute right-2 top-2 h-6 w-6 flex items-center justify-center leading-none bg-gray-500/50 rounded-full z-30" data-action="click->modal#close">
           <%= lucide_icon('x') %>
         </button>

--- a/app/views/posts/image_viewer.turbo_stream.erb
+++ b/app/views/posts/image_viewer.turbo_stream.erb
@@ -35,7 +35,7 @@
           <%= lucide_icon('chevron-left', class: "w-6 h-6") %>
         </button>
 
-        <div class="swiper-pagination !relative !bottom-0 !w-auto !text-black font-black pointer-events-none [-webkit-text-stroke:1px_#fff] text-xl"></div>
+        <%# <div class="swiper-pagination !relative !bottom-0 !w-auto !text-black font-black pointer-events-none [-webkit-text-stroke:1px_#fff] text-xl"></div> %>
 
         <button class="custom-button-next hidden sm:flex items-center justify-center w-12 h-12 rounded-full border-2 border-white bg-black/50 hover:bg-black/80 text-white transition cursor-pointer pointer-events-auto">
           <%= lucide_icon('chevron-right', class: "w-6 h-6") %>

--- a/app/views/posts/preview.turbo_stream.erb
+++ b/app/views/posts/preview.turbo_stream.erb
@@ -6,34 +6,19 @@
 
     <%# --- ボトムシート全体 --- %>
     <div data-bottom-sheet-target="bottomSheetBox"
-          class="relative inset-x-0 bottom-0 z-10 flex flex-col w-full max-h-[60dvh] rounded-t-3xl bg-[#FFFBE6] pb-11 pt-8 shadow-[0_-5px_20px_rgba(0,0,0,0.1)] transition-transform translate-y-full duration-300 pointer-events-auto">
-
-      <%# --- 右上の枠 --- %>
-      <div class="absolute right-1 top-1 z-30 flex items-center gap-2">
-
-        <%# --- 三点リーダボタン --- %>
-        <div class="relative" data-controller="dropdown" data-dropdown-post-url-value="<%= confirm_destroy_post_path(@post) %>">
-          <button type="button"
-                  class="h-10 w-10 flex items-center justify-center bg-gray-500/50 hover:bg-gray-600/60 text-white rounded-full transition"
-                  data-action="click->dropdown#toggle">
-            <%= lucide_icon('ellipsis-vertical', class: "w-6 h-6") %>
-          </button>
-        </div>
-
-        <%# --- バツボタン --- %>
-        <button class="h-10 w-10 flex items-center justify-center bg-gray-500/50 hover:bg-gray-600/60 text-white rounded-full transition" data-action="click->bottom-sheet#close">
-          <%= lucide_icon('x', class: "w-6 h-6") %>
-        </button>
-
-      </div>
+          class="relative inset-x-0 bottom-0 z-10 flex flex-col w-full max-h-[60vh] rounded-t-3xl bg-[#FFFBE6] pb-11 pt-8 shadow-[0_-5px_20px_rgba(0,0,0,0.1)] transition-transform translate-y-full duration-300 pointer-events-auto">
 
       <%# --- ドラッグハンドル --- %>
-      <div class="absolute mx-auto mb-2 h-1.5 w-12 shrink-0 rounded-full bg-gray-300 top-3 left-1/2 -transrate-x-1/2"></div>
+      <div class="absolute mx-auto mb-2 h-1.5 w-12 shrink-0 rounded-full bg-gray-400 top-3 left-1/2 -translate-x-1/2"></div>
 
       <%# --- ヘッダー --- %>
       <div class="modal-header shrink-0 z-20 w-full px-2 sm:px-4">
         <div class="flex items-center justify-between border-b border-orange-200/60 pb-3">
+
+          <%# 左上コンテナ %>
           <div class="flex items-center gap-3">
+
+            <%# アイコン %>
             <% if @post.user.avatar.attached? %>
               <%= image_tag @post.user.avatar, class: "w-10 h-10 object-cover rounded-full shadow-sm" %>
             <% else %>
@@ -41,10 +26,34 @@
                 <%= lucide_icon('user-round', class: "w-6 h-6 text-white") %>
               </div>
             <% end %>
-            <div class="font-bold text-gray-800 text-base"><%= @post.user.nickname %></div>
+
+            <%# ユーザー名と日時 %>
+            <div class="flex flex-col justify-center gap-1">
+              <div class="font-bold text-gray-800 text-base"><%= @post.user.nickname %></div>
+              <div class="text-sm text-gray-500 font-medium">
+                <%= @post.visited_at&.strftime("%Y/%m/%d %H:%M") %>
+              </div>
+            </div>
+
           </div>
-          <div class="text-sm text-gray-500 font-medium">
-            <%= @post.visited_at&.strftime("%Y/%m/%d %H:%M") %>
+
+          <%# --- 右上コンテナ --- %>
+          <div class="flex items-center gap-3">
+
+            <%# --- 三点リーダボタン --- %>
+            <div class="relative" data-controller="dropdown" data-dropdown-post-url-value="<%= confirm_destroy_post_path(@post) %>">
+              <button type="button"
+                      class="h-10 w-10 flex items-center justify-center bg-gray-500/50 hover:bg-gray-600/60 text-white rounded-full transition"
+                      data-action="click->dropdown#toggle">
+                <%= lucide_icon('ellipsis-vertical', class: "w-6 h-6") %>
+              </button>
+            </div>
+
+            <%# --- バツボタン --- %>
+            <button class="h-10 w-10 flex items-center justify-center bg-gray-500/50 hover:bg-gray-600/60 text-white rounded-full transition" data-action="click->bottom-sheet#close">
+              <%= lucide_icon('x', class: "w-6 h-6") %>
+            </button>
+
           </div>
         </div>
       </div>

--- a/app/views/posts/show.turbo_stream.erb
+++ b/app/views/posts/show.turbo_stream.erb
@@ -7,29 +7,14 @@
     <%# モーダル枠 %>
     <div class="relative w-full pointer-events-auto modal-box h-full sm:h-auto bg-[#FFFBE6] max-w-none sm:max-w-5xl max-h-none sm:max-h-[90vh] pt-1 sm:pt-2 pb-6 px-0 sm:px-0  rounded-none sm:rounded-xl gap-4 flex flex-col items-center z-10 transition-all duration-500 ease-out translate-y-40 opacity-0 overflow-hidden" data-modal-target="modalBox">
 
-      <%# --- 右上の枠 --- %>
-      <div class="absolute right-1 top-1 z-30 flex items-center gap-2">
-
-        <%# --- 三点リーダボタン --- %>
-        <div class="relative" data-controller="dropdown" data-dropdown-post-url-value="<%= confirm_destroy_post_path(@post) %>">
-          <button type="button"
-                  class="h-10 w-10 flex items-center justify-center bg-gray-500/50 hover:bg-gray-600/60 text-white rounded-full transition"
-                  data-action="click->dropdown#toggle">
-            <%= lucide_icon('ellipsis-vertical', class: "w-6 h-6") %>
-          </button>
-        </div>
-
-        <%# --- バツボタン --- %>
-        <button class="h-10 w-10 flex items-center justify-center bg-gray-500/50 hover:bg-gray-600/60 text-white rounded-full transition" data-action="click->modal#close">
-          <%= lucide_icon('x', class: "w-6 h-6") %>
-        </button>
-
-      </div>
-
       <%# --- ヘッダー --- %>
       <div class="modal-header shrink-0 z-20 w-full px-2 sm:px-4 pt-2">
         <div class="flex items-center justify-between border-b border-orange-200/60 pb-3">
+
+          <%# 左上コンテナ %>
           <div class="flex items-center gap-3">
+
+            <%# アイコン %>
             <% if @post.user.avatar.attached? %>
               <%= image_tag @post.user.avatar, class: "w-10 h-10 object-cover rounded-full shadow-sm" %>
             <% else %>
@@ -37,16 +22,41 @@
                 <%= lucide_icon('user-round', class: "w-6 h-6 text-white") %>
               </div>
             <% end %>
-            <div class="font-bold text-gray-800 text-base"><%= @post.user.nickname %></div>
+
+            <%# ユーザー名と日時 %>
+            <div class="flex flex-col justify-center gap-1">
+              <div class="font-bold text-gray-800 text-base"><%= @post.user.nickname %></div>
+              <div class="text-sm text-gray-500 font-medium">
+                <%= @post.visited_at&.strftime("%Y/%m/%d %H:%M") %>
+              </div>
+            </div>
+
           </div>
-          <div class="text-sm text-gray-500 font-medium pr-10">
-            <%= @post.visited_at&.strftime("%Y/%m/%d %H:%M") %>
+
+          <%# 右上コンテナ %>
+          <div class="flex items-center gap-3">
+
+            <%# --- 三点リーダボタン --- %>
+            <div class="relative" data-controller="dropdown" data-dropdown-post-url-value="<%= confirm_destroy_post_path(@post) %>">
+              <button type="button"
+                      class="h-10 w-10 flex items-center justify-center bg-gray-500/50 hover:bg-gray-600/60 text-white rounded-full transition"
+                      data-action="click->dropdown#toggle">
+                <%= lucide_icon('ellipsis-vertical', class: "w-6 h-6") %>
+              </button>
+            </div>
+
+            <%# --- バツボタン --- %>
+            <button class="h-10 w-10 flex items-center justify-center bg-gray-500/50 hover:bg-gray-600/60 text-white rounded-full transition" data-action="click->modal#close">
+              <%= lucide_icon('x', class: "w-6 h-6") %>
+            </button>
+
           </div>
+
         </div>
       </div>
 
       <%# --- モーダルの本文と画像枠 --- %>
-      <div class="modal-body flex-1 min-h-0 w-full px-2 sm:px-4 z-20 overflow-y-auto">
+      <div class="modal-body flex-1 min-h-0 w-full px-2 sm:px-4 overflow-y-auto">
 
         <%# 本文 %>
         <% if @post.body.present? %>


### PR DESCRIPTION
## issue
- close: #138 

## 実装内容
- posts/_form.html.erbに訪問日時を設定し、リクエストで送るように追加
- posts_controller.rbのstrong paramaterにvisited_atを追加
- postにvisited_atが未来日にならないようバリデーションを追加
- base_map_controller.jsのopenPostPreviewでpaddingによって想定しない動きになっていたのを修正
- previewの日時の表示場所をユーザー名の下に変更
- image_viewerの日時の表示場所をユーザー名の下に変更  

## issueとの差分
- レイアウトの修正を追加
- バグ修正  

## 動作確認方法
- ブラウザ上で実際に日時が変更できるのか確認
- 日時を変更して投稿したら、変更後の日時が反映されているのか確認
- 日時の上限を設定し、フロントで未来日を設定した時に止まることを確認
- フロントでの上限を一時的に外し、未来日を保存しようとするとバリデーションでDB保存前に弾かれることを確認
- ログで正しいデータが保存されているのか確認 