### PR TITLE
自作目的地検索UI実装

### DIFF
--- a/app/assets/stylesheets/my_style.css
+++ b/app/assets/stylesheets/my_style.css
@@ -82,3 +82,12 @@
 .overflow-x-auto::-webkit-scrollbar-thumb:active {
   background-color: rgba(55, 65, 81, 0.8) !important;
 }
+
+.maplibregl-ctrl-attrib {
+  font-size: clamp(8px, 2.5vw, 12px) !important;
+}
+
+.maplibregl-ctrl-bottom-right {
+  bottom: 0px !important;
+  z-index: 30;
+}

--- a/app/javascript/controllers/base_map_controller.js
+++ b/app/javascript/controllers/base_map_controller.js
@@ -7,9 +7,11 @@ import * as turf from "@turf/turf"
 
 // 定数定義
 const INITIAL_ZOOM_LEVEL = 18;    // 初期のズームレベル
+const DEBUG = false;
 
 // Connects to data-controller="base-map"
 export default class extends Controller {
+  static styleJsonCache = null;
   static outlets = [ "ui", "posts" ]
   static targets = [ "mapOverlay", "appendMarker" ]
   static values = { longitude: Number,
@@ -64,22 +66,21 @@ export default class extends Controller {
     if (!this.ac) return;
 
     const signal = this.ac.signal;
-    const apiKey = this.element.dataset.maptilerKey;
 
     try {
       // 地図のstyleを取得
-      const res = await fetch(`https://api.maptiler.com/maps/jp-mierune-dark/style.json?key=${apiKey}`, { signal: signal });
-      if(!res.ok) throw new Error(`fetch失敗: ${res.status}`);
-
-      this.styleJson = await res.json();
+      const styleJson = await this.loadStyleJson(signal);
 
       if (signal.aborted || !this.element.isConnected) return; // もし connect 中に遷移してたらreturn
+
+      this.styleJson = styleJson;
     } catch (error) {
       if (error.name === "AbortError") {
         console.debug("ページ遷移によるエラー", error);
         return;
       }
-      console.error("地図データの取得に失敗:",error);
+      console.error("style読み込み時の想定外エラー", error);
+      this.styleJson = this.getFallbackStyle();
     }
 
      // 地図の初期化
@@ -90,7 +91,54 @@ export default class extends Controller {
       zoom: INITIAL_ZOOM_LEVEL,
       attributionControl: false,
     });
+  }
 
+  async loadStyleJson(signal){
+    if(this.constructor.styleJsonCache) {
+      console.log("前回のを使用")
+      return structuredClone(this.constructor.styleJsonCache);
+    }
+
+    let apiKey = null;
+
+    if(DEBUG) {
+      apiKey = "test";
+    } else {
+      apiKey = this.element.dataset.maptilerKey;
+    }
+
+    try {
+      const res = await fetch(`https://api.maptiler.com/maps/jp-mierune-dark/style.json?key=${apiKey}`, { signal: signal });
+      if(!res.ok) throw new Error(`fetch失敗: ${res.status}`);
+
+      const styleJson = await res.json();
+      this.constructor.styleJsonCache = structuredClone(styleJson);
+      return structuredClone(styleJson);
+    } catch (error) {
+      if (error.name === "AbortError") {
+        throw error;
+      }
+      console.log("style.json の取得失敗", error);
+      return this.getFallbackStyle();
+    }
+  }
+
+  // 自前のフォールバックスタイル
+  getFallbackStyle() {
+    return {
+      version: 8,
+      sources: {
+      },
+      layers: [
+        {
+          id: "background",
+          type: "background",
+          paint: {
+            "background-color": "#d9eef2"
+          }
+        },
+      ]
+    };
   }
 
   // 渡されたgeohash配列から、結合済みのFeatureを作って返す

--- a/app/javascript/controllers/destination_search_controller.js
+++ b/app/javascript/controllers/destination_search_controller.js
@@ -1,0 +1,495 @@
+import { Controller } from "@hotwired/stimulus"
+import maplibregl from "maplibre-gl"
+import { createGeocoderApi } from "../lib/geocoder_api"
+import { getDistance } from "geolib";
+
+// Connects to data-controller="destination-search"
+export default class extends Controller {
+  static outlets = [
+    "map"
+  ]
+
+  static targets = [
+    "searchPanel",
+    "listPanel",
+    "input",
+    "results",
+    "list",
+    "destinationName",
+    "destinationDistance",
+    "destinationDirection",
+    "destinationInfo",
+    "searchIcon",
+    "loadingIcon",
+    "clearSearchButton",
+  ]
+
+  // 接続時に実行
+  connect() {
+    this.pendingMarkers = []; // 目的地候補のマーカー
+    this.destinations = []; // 目的地の情報たち
+    this.isSearching = false;
+    this.setSearchState("idle");
+
+    this.geocoderApi = createGeocoderApi(this);
+    this.handleLocationUpdate = this.handleLocationUpdate.bind(this);
+    this.handleMapReady = this.handleMapReady.bind(this);
+    this.handleMapRotate = this.handleMapRotate.bind(this);
+
+    window.addEventListener("location:update", this.handleLocationUpdate);
+    window.addEventListener("map:ready", this.handleMapReady);
+
+    this.bindMapEventsIfReady(); // すでにmapが出来ていた場合
+  }
+
+  disconnect() {
+    window.removeEventListener("location:update", this.handleLocationUpdate);
+    window.removeEventListener("map:ready", this.handleMapReady);
+
+    if (this.map) {
+      this.map.off("rotate", this.handleMapRotate);
+    }
+  }
+
+  handleLocationUpdate() {
+    this.updateDestinationInfo();
+  }
+
+  handleMapRotate() {
+    this.updateDestinationDirection();
+  }
+
+  handleMapReady() {
+    this.bindMapEventsIfReady();
+  }
+
+  bindMapEventsIfReady() {
+    if (!this.map) return;
+    if (this.mapEventsBound) return;
+
+    this.map.on("rotate", this.handleMapRotate);
+    this.mapEventsBound = true;
+  }
+
+  // --- UIの表示設定 ----
+  // 検索の状態と表示を管理
+  setSearchState(state){
+    this.searchState = state;
+
+    this.searchIconTarget.classList.toggle("hidden", state !== "idle");
+    this.loadingIconTarget.classList.toggle("hidden", state !== "loading");
+  }
+
+  toggleSearch(){
+    this.searchPanelTarget.classList.toggle("hidden");
+    this.listPanelTarget.classList.add("hidden")
+  }
+
+  closeSearch() {
+    this.hideSearchPanel();
+  }
+
+  closeList() {
+    this.hideListPanel();
+  }
+
+  hideSearchPanel() {
+    this.searchPanelTarget.classList.add("hidden")
+  }
+
+  hideListPanel() {
+    this.listPanelTarget.classList.add("hidden")
+  }
+
+  toggleList() {
+    this.listPanelTarget.classList.toggle("hidden")
+    this.searchPanelTarget.classList.add("hidden")
+  }
+  // --- UIの表示設定ここまで ---
+
+  // --- ゲッターの設定 ---
+  get currentPosition(){
+    return this.hasMapOutlet ? this.mapOutlet.getCurrentPosition() : null;
+  }
+
+  get currentLat(){
+    return this.currentPosition?.lat ?? null;
+  }
+
+  get currentLng(){
+    return this.currentPosition?.lng ?? null;
+  }
+
+  get map(){
+    return this.hasMapOutlet ? this.mapOutlet.getMap() : null;
+  }
+  // --- ゲッターの設定ここまで ---
+
+  // geolocateのトラッキングを停止
+  disableGeolocateTracking() {
+    if(this.hasMapOutlet){
+      this.mapOutlet.disableGeolocateTracking()
+    }
+  }
+
+  async search(event){
+    event.preventDefault();
+
+    if (this.searchState === "loading") return;
+
+    const query = this.inputTarget.value.trim(); // 入力された文字列を整形
+
+    // queryが空の場合は検索結果と結果マーカーをクリアする
+    if(!query){
+      this.clearSearchState();
+      return;
+    }
+
+    this.setSearchState("loading");
+
+    this.clearSearchState();
+
+    try {
+      const response = await this.geocoderApi.forwardGeocode({ query });
+      const features = response.features || [];
+
+      this.renderSearchResults(features);
+      this.renderPendingMarkers(features);
+    } catch (error) {
+      console.error("destination search error:", error);
+      this.clearSearchState();
+    } finally {
+      this.setSearchState("idle");
+    }
+  }
+
+  // 検索結果をリストに表示
+  renderSearchResults(features){
+    this.clearSearchResults();
+
+    this.clearSearchButtonTarget.classList.remove("hidden")
+
+    if(features.length === 0){
+      const li = document.createElement("li");
+      li.className = "rounded-xl bg-white/60 px-3 py-1 text-sm text-gray-800 shadow-sm";
+      li.textContent = "検索結果が見つかりませんでした";
+      this.resultsTarget.appendChild(li);
+      return;
+    }
+
+    features.forEach(feature => {
+      const li = document.createElement("li");
+      li.className = "rounded-xl bg-white/60 px-3 py-2 text-sm text-gray-800 shadow-sm cursor-pointer hover:bg-gray-200/60 active:scale-95 active:shadow-sm transition";
+
+      const placeName = feature.place_name.split(",");
+
+      const divName = document.createElement("div");
+      divName.className = "text-sm font-semibold"
+
+      const divData = document.createElement("div");
+      divData.className = "text-xs text-gray-500"
+
+      divName.textContent = placeName[0]
+      divData.textContent = placeName.slice(1).join(",");
+
+      li.appendChild(divName);
+      li.appendChild(divData);
+      this.resultsTarget.appendChild(li);
+
+      li.addEventListener("click", () => {
+        const coords = feature.center || feature.geometry.coordinates; // 座標をセット
+        this.disableGeolocateTracking(); // 現在地追従をオフ
+        this.hideSearchPanel();
+
+        this.map.flyTo({
+          center: coords,
+          zoom: 16
+        });
+      });
+    })
+  }
+
+  // 検索結果のマーカーを地図上に表示
+  renderPendingMarkers(features){
+    console.log("マーカーを描画:",features);
+    if(!this.map || !this.hasMapOutlet) return;
+
+    const lng = this.currentLng;
+    const lat = this.currentLat;
+
+    const bounds = new maplibregl.LngLatBounds(); // 箱を用意
+    if (lng != null && lat != null) {
+      bounds.extend([lng, lat]); // 現在地を格納
+    }
+
+    features.forEach(feature => {
+      const placeName = feature.place_name.split(",")[0];
+      const coords = feature.center || feature.geometry.coordinates;
+      bounds.extend(coords); // 検索結果の座標を箱に格納
+
+      // マーカーを地図に追加
+      const marker = new maplibregl.Marker({color: "#f233e9"})
+        .setLngLat(coords)
+        .addTo(this.map)
+
+      // マーカーに名前を表示
+      const el = marker.getElement();
+      const label = document.createElement('div');
+      label.textContent = placeName || feature.text || feature.properties?.name || "目的地候補";
+      label.className = "absolute -top-7 left-1/2 -translate-x-1/2 bg-white/90 px-2 py-0.5 rounded text-xs font-bold text-gray-800 whitespace-nowrap pointer-events-none shadow-sm";
+      el.appendChild(label);
+
+      // マーカーをクリックで目的地として登録するモーダルを表示
+      el.addEventListener("click", () => {
+        this.openConfirmDestinationModal(feature, coords);
+      })
+      this.pendingMarkers.push(marker);
+    })
+
+    // 全ての目的地が表示されるようにカメラを移動
+    if (!bounds.isEmpty()) {
+      this.disableGeolocateTracking();
+
+      this.map.fitBounds(bounds, {
+        padding: 130,
+        duration: 1000,
+        maxZoom: 16
+      });
+    }
+  }
+
+  // 検索結果をクリア
+  clearSearchResults(){
+    this.resultsTarget.innerHTML = "";
+  }
+
+  clearSearchState() {
+    this.clearSearchResults();
+    this.clearPendingMarkers();
+    this.clearSearchButtonTarget.classList.add("hidden");
+  }
+
+  clearSearchAll() {
+    this.inputTarget.value = '';
+    this.clearSearchState();
+  }
+
+  // 検索結果のマーカーをクリア
+  clearPendingMarkers(){
+    if (this.pendingMarkers && this.pendingMarkers.length > 0) {
+      this.pendingMarkers.forEach(marker => {
+        marker.remove();
+      });
+      this.pendingMarkers = [];
+    }
+  }
+
+  // 目的地を登録するのか確認
+  openConfirmDestinationModal(feature, coords){
+    const ok = window.confirm(`ここを目的地${this.destinations.length + 1}としてセットしますか？`);
+    if (!ok) return;
+
+    this.addConfirmedDestination(feature, coords); // 目的地を登録
+    this.inputTarget.value = ""
+    this.clearSearchState(); // 検索結果とマーカーを削除
+    this.hideSearchPanel();
+    this.updateDestinationInfo();
+  }
+
+  // 目的地を追加
+  addConfirmedDestination(feature, coords){
+    const placeName = feature.place_name.split(",")[0] || feature.text || feature.properties?.name || "目的地"; // 目的地の名前を設定
+
+    // マーカーを追加
+    const marker = new maplibregl.Marker({color: "#42f587"})
+      .setLngLat(coords)
+      .addTo(this.map);
+
+    // マーカーに名前を追加
+    const el = marker.getElement();
+    const label = document.createElement('div');
+    label.textContent = placeName;
+    label.className = "absolute -top-7 left-1/2 -translate-x-1/2 bg-white/90 px-2 py-0.5 rounded text-xs font-bold text-gray-800 whitespace-nowrap pointer-events-none shadow-sm";
+    el.appendChild(label);
+
+    // マーカーにイベントリスナーを登録
+    el.addEventListener('click', (e) => {
+      e.stopPropagation();
+
+      const currentIndex = this.destinations.findIndex(dest => dest.marker === marker); // 削除する要素の順番を取得
+
+      if (currentIndex !== -1) {
+        this.removeDestination(currentIndex); // 見つかったら配列からデータを削除
+      }
+    });
+
+    // 配列にデータを追加
+    this.destinations.push({
+      name: placeName,
+      lng: coords[0],
+      lat: coords[1],
+      marker: marker,
+      labelElement: label,
+    })
+
+    this.updateDestinationList(); // リストの描画と順番の更新
+  }
+
+  // 目的地リストをデータに合わせて描画
+  updateDestinationList() {
+    const ul = this.listTarget;
+    ul.innerHTML = ''; // 一旦リストを空に
+
+    // 目的地がゼロになったらコンテナごと隠す
+    if (this.destinations.length === 0) {
+      this.listPanelTarget.classList.add('hidden');
+      return;
+    }
+
+    this.listPanelTarget.classList.remove('hidden'); // 目的地リストを表示
+
+    // 配列をループしてリストとマーカーを作り直す
+    this.destinations.forEach((dest, index) => {
+      const order = index + 1; // orderに順番を設定
+
+      // マーカーのラベルにテキストコンテンツに順番と名前をセット
+      dest.labelElement.textContent = `${order}. ${dest.name}`;
+
+      // リストを作成
+      const li = document.createElement('li');
+      li.className = "flex items-center justify-between rounded-xl bg-white/10 px-2 py-2 shadow-sm cursor-pointer hover:bg-gray-200/80 active:scale-95 active:shadow-sm transition";
+      li.innerHTML = `
+        <div class="flex items-center gap-3 overflow-hidden">
+          <span class="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full bg-green-500 text-sm font-bold text-white">${order}</span>
+          <span class="truncate text-sm font-medium text-gray-800">${dest.name}</span>
+        </div>
+        <button class="flex-shrink-0 text-gray-400 hover:text-red-500 transition-opacity p-1 focus:outline-none">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M18 6L6 18M6 6l12 12"></path>
+          </svg>
+        </button>
+      `
+
+      // 削除ボタンのイベントを設定
+      const deleteBtn = li.querySelector('button');
+
+      // 削除ボタンにイベントリスナーを設定
+      deleteBtn.addEventListener('click', (e) => {
+        e.stopPropagation(); // イベントの伝播を停止
+        this.removeDestination(index); // 目的地を削除
+      });
+
+      // リストにカメラを移動させるイベントリスナーを設定
+      li.addEventListener('click', (e) => {
+        e.stopPropagation(); // イベントの伝播を停止
+
+        const lng = this.currentLng;
+        const lat = this.currentLat;
+
+        const bounds = new maplibregl.LngLatBounds(); // 箱を用意
+
+        if (lng != null && lat != null) {
+          bounds.extend([lng, lat]); // 現在地を格納
+        }
+        bounds.extend([dest.lng, dest.lat]); // 目的地の座標を箱に格納
+
+        // boundsが全て見えるようにカメラを移動
+        if (!bounds.isEmpty()) {
+          this.disableGeolocateTracking();
+
+          this.map.fitBounds(bounds, {
+            padding: 130,
+            duration: 1000,
+            maxZoom: 16
+          });
+        }
+      });
+
+      ul.appendChild(li); // リストに要素を追加
+    });
+  }
+
+  // 目的地を削除
+  removeDestination(index) {
+    const placeName = this.destinations[index].name; // 名前を取得
+
+    const ok = window.confirm(`目的地「${placeName}」を削除しますか？`);
+    if (!ok) return;
+
+    this.destinations[index].marker.remove(); // 地図上からマーカー消去
+    this.destinations.splice(index, 1); // 配列のデータを削除
+
+    this.updateDestinationList(); // 更新後のデータで再描画
+    this.updateDestinationInfo();
+  }
+
+  // 目的地までの距離方角を更新
+  updateDestinationInfo(){
+    if(this.destinations.length === 0 || this.currentLat == null || this.currentLng == null){
+      this.destinationNameTarget.textContent = '';
+      this.destinationDistanceTarget.textContent = '';
+      this.destinationInfoTarget.classList.add("hidden");
+      return;
+    }
+
+    const name = this.destinations[0].name;
+    const distanceLng = this.destinations[0].lng;
+    const distanceLat = this.destinations[0].lat;
+
+    const dist = getDistance(
+      { latitude: this.currentLat, longitude: this.currentLng }, // 現在地
+      { latitude: distanceLat, longitude: distanceLng }  // 目的地
+    );
+    let distText = "";
+
+    if(dist > 999){
+      distText += (dist / 1000).toFixed(1);
+      distText += " km"
+    } else {
+      distText += Math.round(dist);
+      distText += " m";
+    }
+
+    this.destinationNameTarget.textContent = name;
+    this.destinationDistanceTarget.textContent = distText;
+    this.destinationInfoTarget.classList.remove("hidden");
+    this.updateDestinationDirection();
+  }
+
+  // 目的地のまでの方角を更新
+  updateDestinationDirection() {
+    if (this.destinations.length === 0 || this.currentLat == null || this.currentLng == null) return;
+
+    const destination = this.destinations[0];
+
+    const targetBearing = this.calculateBearing(
+      this.currentLat,
+      this.currentLng,
+      destination.lat,
+      destination.lng
+    );
+
+    const mapBearing = this.map.getBearing(); // 地図の回転角
+    const rotate = targetBearing - mapBearing;
+
+    this.destinationDirectionTarget.style.transform = `rotate(${rotate}deg)`;
+  }
+
+  // 方角を計算
+  calculateBearing(lat1, lng1, lat2, lng2) {
+    const toRad = (deg) => deg * Math.PI / 180;
+    const toDeg = (rad) => rad * 180 / Math.PI;
+
+    const φ1 = toRad(lat1);
+    const φ2 = toRad(lat2);
+    const Δλ = toRad(lng2 - lng1);
+
+    const y = Math.sin(Δλ) * Math.cos(φ2);
+    const x =
+      Math.cos(φ1) * Math.sin(φ2) -
+      Math.sin(φ1) * Math.cos(φ2) * Math.cos(Δλ);
+
+    const bearing = toDeg(Math.atan2(y, x));
+    return (bearing + 360) % 360;
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -16,6 +16,9 @@ application.register("bottom-sheet", BottomSheetController)
 import CopyController from "./copy_controller"
 application.register("copy", CopyController)
 
+import DestinationSearchController from "./destination_search_controller"
+application.register("destination-search", DestinationSearchController)
+
 import DispatchController from "./dispatch_controller"
 application.register("dispatch", DispatchController)
 

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -5,9 +5,6 @@ import 'maplibre-gl/dist/maplibre-gl.css'
 import ngeohash from 'ngeohash';
 import { getDistance } from 'geolib'
 import * as turf from "@turf/turf"
-import MaplibreGeocoder from '@maplibre/maplibre-gl-geocoder'
-import '@maplibre/maplibre-gl-geocoder/dist/maplibre-gl-geocoder.css'
-import { createGeocoderApi } from "../lib/geocoder_api"
 
 // 定数定義
 const GEOHASH_PRECISION     = 9;     // 保存するgeohash精度
@@ -22,7 +19,7 @@ const DEBUG_MODE            = false;
 
 // Connects to data-controller="map"
 export default class extends BaseMapController {
-  async connect() {
+  connect() {
     if (document.documentElement.hasAttribute("data-turbo-preview")) return; // プレビューの時は戻る
 
     console.log("-----初期化実行-----")
@@ -34,15 +31,7 @@ export default class extends BaseMapController {
     this.setupEventListeners(); // イベントリスナーを登録
     if (this.ac.signal.aborted || !this.element.isConnected) return; // 途中で遷移してたらreturn
 
-    this.center = [ 139.745, 35.658 ]; // 仮の中央として東京駅
-    await this.initializeMap(this.center) // 地図初期化
-    if (!this.map) return;
-
-    this.setupMapControls(); // 地図のUI設定
-    this.setupPulseMarker(); // 現在地のパルス設定
-    this.addMarkers(); // マーカーをセット
-    this.setupMapLoadEvents(); // 地図読み込み後の処理
-    console.log("-----初期化終了-----")
+    this.setupMapProcess(); // マップ関連の処理を実行
   }
 
   // --- セットアップ関連メソッド ---
@@ -89,10 +78,22 @@ export default class extends BaseMapController {
     document.addEventListener('visibilitychange', this.onVisibilityChange, { signal: this.ac.signal });
   }
 
+  async setupMapProcess(){
+    this.center = [ 139.745, 35.658 ]; // 仮の中央として東京駅
+    await this.initializeMap(this.center) // 地図初期化
+    if (!this.map || this.ac.signal.aborted || !this.element.isConnected) return;
+
+    this.setupMapControls(); // 地図のUI設定
+    this.setupPulseMarker(); // 現在地のパルス設定
+    this.addMarkers(); // マーカーをセット
+    this.setupMapLoadEvents(); // 地図読み込み後の処理
+    console.log("-----初期化終了-----")
+  }
+
   // 地図のUI設定
   setupMapControls(){
     // アトリビューション表記
-    this.map.addControl(new maplibregl.AttributionControl({ compact: true }), "top-right");
+    this.map.addControl(new maplibregl.AttributionControl({ compact: true, customAttribution: '© <a href="https://www.geoapify.com/" target="_blank" rel="noopener noreferrer">Geoapify</a>' }), "bottom-right");
 
     // 現在地追跡機能をセット
     this.geolocate = new maplibregl.GeolocateControl({
@@ -107,7 +108,15 @@ export default class extends BaseMapController {
       }
     });
 
+    // ナビゲーションコントロールボタンを設定
+    const navControl = new maplibregl.NavigationControl({
+      showCompass: true, // コンパスを表示
+      showZoom: false,    // ズームボタンを表示
+      visualizePitch: true // マップの傾きに合わせてコンパスを傾ける
+    });
+
     this.map.addControl(this.geolocate); // 地図にgeolocateボタンを追加。右上
+    this.map.addControl(navControl); // 地図にナビゲーションボタンを追加
     this.overrideGeolocateTrigger(); // geolocateボタンのtriggerメソッドを上書き
 
     this.geolocate.on('geolocate', this.handleGeolocate); // geolocate発火時に起動する関数の設定
@@ -123,118 +132,6 @@ export default class extends BaseMapController {
         this.pulseMarker.getElement().style.display = "none";
       }
     });
-
-    this.setupGeocoder(); // 検索の設定
-  }
-
-  setupGeocoder(){
-    this.pendingMarkers = []; // 目的地候補のマーカー
-    this.destinations = []; // 目的地の情報たち
-
-    const geocoderApi = createGeocoderApi(this);
-
-    this.geocoder = new MaplibreGeocoder(
-      geocoderApi,
-      {
-        maplibregl,
-        marker: false,
-        showResultMarkers: false,
-        flyTo: false,
-        limit: 10,
-        minLength: 1,
-        showResultsWhileTyping: false,
-        debounceSearch: 500,
-        placeholder: "目的地を検索"
-      }
-    )
-
-    // 検索結果が複数ある時
-    this.geocoder.on("results", (e) => {
-      // すでに存在しているマーカーを削除
-      this.pendingMarkers.forEach(marker => {
-        marker.remove();
-      })
-      this.pendingMarkers = [];
-
-      const bounds = new maplibregl.LngLatBounds(); // 箱を用意
-      bounds.extend([this.currentLng, this.currentLat]); // 現在地を格納
-
-      // 検索結果のマーカーを地図上に表示
-      e.features.forEach(feature => {
-        const placeName = feature.place_name.split(",")[0];
-        const coords = feature.center || feature.geometry.coordinates;
-        bounds.extend(coords); // 検索結果の座標を箱に格納
-
-        // マーカーを地図に追加
-        const marker = new maplibregl.Marker({color: "#f233e9"})
-          .setLngLat(coords)
-          .addTo(this.map)
-
-        // マーカーに名前を表示
-        const el = marker.getElement();
-        const label = document.createElement('div');
-        label.textContent = placeName || feature.text || feature.properties?.name || "目的地候補";
-        label.className = "absolute -top-7 left-1/2 -translate-x-1/2 bg-white/90 px-2 py-0.5 rounded text-xs font-bold text-gray-800 whitespace-nowrap pointer-events-none shadow-sm";
-        el.appendChild(label);
-
-        // マーカーを目的地として登録するモーダルを表示
-        el.addEventListener("click", () => {
-          this.openConfirmDestinationModal(feature, coords);
-        })
-        this.pendingMarkers.push(marker);
-      })
-
-      // 全ての目的地が表示されるようにカメラを移動
-      if (!bounds.isEmpty()) {
-        this.disableGeolocateTracking();
-
-        this.map.fitBounds(bounds, {
-          padding: 80,
-          duration: 1000,
-          maxZoom: 16
-        });
-      }
-    })
-
-    // 検索結果をタップしたとき
-    this.geocoder.on("result", (e) => {
-      const feature = e.result;
-      const coords = feature.center || feature.geometry.coordinates;
-
-      this.disableGeolocateTracking(); // 現在地追従をオフ
-
-      this.map.flyTo({
-        center: coords,
-        zoom: 16
-      })
-    })
-
-    // 検索の×ボタンが押された、または入力が空になった時
-    this.geocoder.on("clear", () => {
-      // 一時的なマーカーを全て削除
-      if (this.pendingMarkers && this.pendingMarkers.length > 0) {
-        this.pendingMarkers.forEach(marker => {
-          marker.remove();
-        });
-        this.pendingMarkers = [];
-      }
-    });
-
-    this.geocoder.on("error", (e) => {
-      console.error("MaplibreGeocoder error event:", e)
-    })
-
-    this.map.addControl(this.geocoder, 'top-left'); // 検索機能を画面左上に追加
-
-    // 検索結果リストを検索窓の下に追加
-    this.destinationListContainer = document.createElement('div');
-    this.destinationListContainer.className = "maplibregl-ctrl bg-white/95 rounded-md shadow-md p-3 w-[300px] pointer-events-auto hidden";
-    this.destinationListContainer.innerHTML = `<h3 class="text-sm font-bold text-gray-700 mb-2 border-b pb-1">目的地リスト</h3><ul id="destination-list-ul" class="space-y-2"></ul>`;
-
-    const topLeftCtrl = document.querySelector('.maplibregl-ctrl-top-left');
-    if (topLeftCtrl) {
-      topLeftCtrl.appendChild(this.destinationListContainer);
-    }
   }
 
   // 現在地追従をオフ
@@ -251,147 +148,6 @@ export default class extends BaseMapController {
         }
       }
     }
-  }
-
-  // 目的地を登録するのか確認
-  openConfirmDestinationModal(feature, coords){
-    const ok = window.confirm(`ここを目的地${this.destinations.length + 1}としてセットしますか？`);
-    if (!ok) return;
-
-    this.addConfirmedDestination(feature, coords); // 目的地を登録
-
-    // 仮の目的地を削除
-    if(this.pendingMarkers && this.pendingMarkers.length > 0){
-      this.pendingMarkers.forEach(marker => {
-        marker.remove();
-      })
-      this.pendingMarkers = [];
-    }
-
-    this.geocoder.clear(); // 入力欄をクリア
-  }
-
-  // 目的地を追加
-  addConfirmedDestination(feature, coords){
-    const placeName = feature.place_name.split(",")[0] || feature.text || feature.properties?.name || "目的地"; // 目的地の名前を設定
-
-    // マーカーを追加
-    const marker = new maplibregl.Marker({color: "#42f587"})
-      .setLngLat(coords)
-      .addTo(this.map);
-
-    // マーカーに名前を追加
-    const el = marker.getElement();
-    const label = document.createElement('div');
-    label.textContent = placeName || feature.text || feature.properties?.name || "目的地候補";
-    label.className = "absolute -top-7 left-1/2 -translate-x-1/2 bg-white/90 px-2 py-0.5 rounded text-xs font-bold text-gray-800 whitespace-nowrap pointer-events-none shadow-sm";
-    el.appendChild(label);
-
-    // マーカーにイベントリスナーを登録
-    el.addEventListener('click', (e) => {
-      e.stopPropagation();
-
-      const ok = window.confirm(`目的地「${placeName}」を削除しますか？`);
-      if (!ok) return;
-
-      const currentIndex = this.destinations.findIndex(dest => dest.marker === marker); // 削除する要素の順番を取得
-
-      if (currentIndex !== -1) {
-        this.removeDestination(currentIndex); // 見つかったら配列からデータを削除
-      }
-    });
-
-    // 配列にデータを追加
-    this.destinations.push({
-      name: placeName,
-      lng: coords[0],
-      lat: coords[1],
-      marker: marker,
-      labelElement: label,
-    })
-
-    this.updateDestinationList(); // リストの描画と順番の更新
-  }
-
-  // 目的地リストをデータに合わせて描画
-  updateDestinationList() {
-    const ul = this.destinationListContainer.querySelector('#destination-list-ul');
-    ul.innerHTML = ''; // 一旦リストを空に
-
-    // 目的地がゼロになったらコンテナごと隠す
-    if (this.destinations.length === 0) {
-      this.destinationListContainer.classList.add('hidden');
-      return;
-    }
-
-    this.destinationListContainer.classList.remove('hidden'); // 目的地リストを表示
-
-    // 配列をループしてリストとマーカーを作り直す
-    this.destinations.forEach((dest, index) => {
-      const order = index + 1; // orderに順番を設定
-
-      // マーカーのラベルにテキストコンテンツに順番と名前をセット
-      dest.labelElement.textContent = `${order}. ${dest.name}`;
-
-      // リストを作成
-      const li = document.createElement('li');
-      li.className = "text-sm text-gray-800 flex items-center justify-between gap-2 group p-1 hover:bg-gray-50 rounded transition-colors";
-      li.innerHTML = `
-        <div class="flex items-center gap-2 overflow-hidden">
-          <span class="flex-shrink-0 bg-green-500 text-white w-5 h-5 rounded-full flex items-center justify-center text-xs font-bold">${order}</span>
-          <span class="leading-tight truncate">${dest.name}</span>
-        </div>
-        <button class="flex-shrink-0 text-gray-400 hover:text-red-500 transition-opacity p-1 focus:outline-none">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <path d="M18 6L6 18M6 6l12 12"></path>
-          </svg>
-        </button>
-      `;
-
-      // 削除ボタンのイベントを設定
-      const deleteBtn = li.querySelector('button');
-
-      // 削除ボタンにイベントリスナーを設定
-      deleteBtn.addEventListener('click', (e) => {
-        e.stopPropagation(); // イベントの伝播を停止
-        this.removeDestination(index); // 目的地を削除
-      });
-
-      // リストにカメラを移動させるイベントリスナーを設定
-      li.addEventListener('click', (e) => {
-        e.stopPropagation(); // イベントの伝播を停止
-
-        const bounds = new maplibregl.LngLatBounds(); // 箱を用意
-        bounds.extend([this.currentLng, this.currentLat]); // 現在地を格納
-        bounds.extend([dest.lng, dest.lat]); // 目的地の座標を箱に格納
-
-        // boundsが全て見えるようにカメラを移動
-        if (!bounds.isEmpty()) {
-          this.disableGeolocateTracking();
-
-          this.map.fitBounds(bounds, {
-            padding: 80,
-            duration: 1000,
-            maxZoom: 16
-          });
-        }
-      });
-
-      ul.appendChild(li); // リストに要素を追加
-    });
-  }
-
-  // 目的地を削除
-  removeDestination(index) {
-    const placeName = this.destinations[index].name; // 名前を取得
-
-    const ok = window.confirm(`目的地「${placeName}」を削除しますか？`);
-    if (!ok) return;
-
-    this.destinations[index].marker.remove(); // 地図上からマーカー消去
-    this.destinations.splice(index, 1); // 配列のデータを削除
-
-    this.updateDestinationList(); // 更新後のデータで再描画
   }
 
   // geolocateボタンのtriggerメソッドを上書き
@@ -489,7 +245,86 @@ export default class extends BaseMapController {
       const empty = new Uint8Array([0, 0, 0, 0]);
       this.map.addImage(id, { width: 1, height: 1, data: empty });
     });
+
+    window.dispatchEvent(new CustomEvent("map:ready")); // map準備完了のイベントを発火
   }
+
+  jumpToCurrentLocation() {
+    if (this.currentLat != null && this.currentLng != null) {
+
+      // 現在地にズーム18で移動
+      this.map.easeTo({
+        center: [this.currentLng, this.currentLat],
+        zoom: 18,
+        duration: 1000,
+        essential: true // 強制的にアニメーション
+      });
+
+      // 移動が終わったら一回だけ起動
+      this.map.once('moveend', () => {
+        console.log("ムーブエンド")
+        console.log("ムーブエンド")
+        console.log("ムーブエンド")
+        if (this.geolocate) {
+          if (this.geolocate._watchState === 'BACKGROUND') {
+            this.geolocate._watchState = 'ACTIVE_LOCK'; // geolocateの状態を追従モードへ
+            const btn = this.geolocate._geolocateButton;
+
+            if (btn) {
+              btn.classList.remove('maplibregl-ctrl-geolocate-background');
+              btn.classList.add('maplibregl-ctrl-geolocate-active');
+            }
+          } else if(this.geolocate._watchState === 'OFF') {
+            this.geolocateTrigger();
+          }
+        }
+      });
+    } else {
+      console.warn("現在地がまだ取得できていません");
+    }
+  }
+
+  // jumpToCurrentLocation() {
+  //   if (!this.currentLat || !this.currentLng) {
+  //     console.warn("現在地がまだ取得できていません");
+  //     return;
+  //   }
+
+  //   if (this.geolocate && this.geolocate._watchState === 'OFF') {
+  //     // 【OFFの場合】
+  //     // GPS監視とドット生成を起動するため、素直にネイティブの trigger() に任せる。
+  //     // ただし、ズームを強制的に18にするため、一瞬だけオプションを上書きするハックを使います。
+      
+  //     const originalMaxZoom = this.geolocate.options.fitBoundsOptions.maxZoom;
+  //     this.geolocate.options.fitBoundsOptions.maxZoom = 18; // ズーム18を強制
+      
+  //     this.geolocate.trigger(); // これでドットも生成され、現在地へ移動する
+      
+  //     // （※もし通常の現在地ボタンを押した時は元のズーム制限に戻したいなら、
+  //     // 適当なタイミングで originalMaxZoom に戻す処理を入れても良いです）
+
+  //   } else {
+  //     // 【BACKGROUND または ACTIVE_LOCK の場合】
+  //     // すでに起動中（ドットは存在している）なので、自作の easeTo で美しく移動し、
+  //     // ステータスの書き換えでUIを同期させるだけでOK！
+
+  //     this.map.easeTo({
+  //       center: [this.currentLng, this.currentLat],
+  //       zoom: 18,
+  //       duration: 1000,
+  //       essential: true
+  //     });
+
+  //     if (this.geolocate && this.geolocate._watchState === 'BACKGROUND') {
+  //       this.geolocate._watchState = 'ACTIVE_LOCK';
+  //       const btn = this.geolocate._geolocateButton;
+  //       if (btn) {
+  //         btn.classList.remove('maplibregl-ctrl-geolocate-background');
+  //         btn.classList.add('maplibregl-ctrl-geolocate-active');
+  //       }
+  //     }
+  //   }
+  // }
 
   // --- ロジック関連メソッド ---
 
@@ -527,6 +362,8 @@ export default class extends BaseMapController {
     this.mapInitEnd = true;
     this.maybeClearOverlay();
 
+    this.dispatchLocationUpdate(); // location:updateイベントを発火
+
     // status が RECORDING になっている場合に保存判定
     if(this.status === STATUS.RECORDING) {
       this.checkAndBufferFootprint(this.currentGeohash);
@@ -552,6 +389,9 @@ export default class extends BaseMapController {
         } else if (result.state === 'granted'){ // 許可しているとき
 
           if (this.map && this.geolocate) {
+            this.map.jumpTo({
+              center: [this.currentLng, this.currentLat]
+            })
             this.geolocate.trigger(); // 地図上の現在地ボタンを起動
             this.mapInitEnd = true;   // 地図の設定完了フラグをtrueに
             this.maybeClearOverlay(); // 霧を晴らす
@@ -1122,80 +962,25 @@ export default class extends BaseMapController {
   fogOn(){
     this.setFogOpacity(0.9);
   }
-  // // geocoderをセット
-  // setGeocoderApi(){
-  //   const requestOptions = {
-  //     method: 'GET',
-  //   };
 
-  //   this.geocoderApi = {
-  //     // 検索ボックスに文字が入力された瞬間発火
-  //     forwardGeocode: async (config) => {
-  //       const features = [];
-  //       try {
-  //         const center = this.map.getCenter();
+  getCurrentPosition(){
+    return { lng: this.currentLng, lat: this.currentLat }
+  }
 
-  //         const url = new URL("https://api.geoapify.com/v2/places");
-  //         url.searchParams.set("categories", "public_transport");
-  //         url.searchParams.set("name", config.query);
-  //         url.searchParams.set("bias", `proximity:${this.currentLng},${this.currentLat}`);
-  //         url.searchParams.set("filter", `circle:${this.currentLng},${this.currentLat},50000`);
-  //         url.searchParams.set("limit", "10");
-  //         url.searchParams.set("lang", "ja");
-  //         url.searchParams.set("apiKey", GEOAPIFY_API_KEY);
+  getCurrentLat() {
+    return this.currentLat
+  }
 
-  //         // const request =
-  //         //   `https://api.geoapify.com/v2/places` +
-  //         //   `?categories=public_transport` +
-  //         //   `&name=${encodeURIComponent(config.query)}` +
-  //         //   `&bias=proximity:${center.lng},${center.lat}` +
-  //         //   `&filter=circle:${center.lng},${center.lat},50000` +
-  //         //   `&limit=10` +
-  //         //   `&lang=ja` +
-  //         //   `&apiKey=${GEOAPIFY_API_KEY}`;
+  getCurrentLng() {
+    return this.currentLng
+  }
 
-  //         const response = await fetch(url);
+  getMap() {
+    return this.map
+  }
 
-  //         if (!response.ok) {
-  //           throw new Error(`Geoapify request failed: ${response.status}`);
-  //         }
-
-  //         const geojson = await response.json();
-
-  //         // maplibre用にデータを整形
-  //         for (const feature of (geojson.features || [])){
-  //           const props = feature.properties || {};
-  //           const center = feature.geometry?.coordinates ||
-  //           (feature.bbox ? [
-  //             feature.bbox[0] + (feature.bbox[2] - feature.bbox[0]) / 2,
-  //             feature.bbox[1] + (feature.bbox[3] - feature.bbox[1]) / 2
-  //           ] : null);
-
-  //           if (!center) continue;
-
-  //           const label =
-  //             props.name ||
-  //             props.address_line1 ||
-  //             props.formatted ||
-  //             `${props.city || props.state || "名称不明"}`;
-
-  //           features.push({
-  //             type: 'Feature',
-  //             geometry: { type: 'Point', coordinates: center },
-  //             place_name: String(props.formatted || label),
-  //             properties: props,
-  //             text: String(label),
-  //             place_type: [props.result_type || "place"],
-  //             center: center
-  //           });
-  //         }
-  //       } catch(e) {
-  //         console.error(`Geocodingエラー: ${e}`);
-  //       }
-  //       this.setFogOpacity(0.0);
-  //       console.log(features)
-  //       return { features: features };
-  //     }
-  //   }
-  // }
+  dispatchLocationUpdate(){
+    window.dispatchEvent(new CustomEvent("location:update", {
+    }))
+  }
 }

--- a/app/javascript/controllers/ui_controller.js
+++ b/app/javascript/controllers/ui_controller.js
@@ -154,7 +154,7 @@ export default class extends Controller {
       case STATUS.STOPPED:
         if (this.hasPlayButtonTarget) {
           this.playButtonTarget.classList.remove("hidden")
-          this.pauseButtonContainerTarget.classList.add("translate-y-[calc(100%+6rem)]")
+          this.pauseButtonContainerTarget.classList.add("translate-y-[calc(100%+7rem)]")
           this.rightNormalButtonContainerTarget.classList.remove("translate-x-[calc(100%+8px)]")
           this.pauseButtonTarget.classList.add("hidden")
           this.leftButtonContainerTarget.classList.add("-translate-x-full")
@@ -172,13 +172,13 @@ export default class extends Controller {
         this.rightNormalButtonContainerTarget.classList.add("translate-x-[calc(100%+8px)]")
         this.rightRecordingButtonContainerTarget.classList.remove("translate-x-[calc(100%+8px)]")
         this.bottomSheetTarget.classList.add("translate-y-full")
-        this.pauseButtonContainerTarget.classList.add("translate-y-[calc(100%+6rem)]")
+        this.pauseButtonContainerTarget.classList.add("translate-y-[calc(100%+7rem)]")
         break;
       // 地図記録一時停止中になった時
       case STATUS.PAUSED:
         this.playButtonTarget.classList.remove("hidden")
         this.pauseButtonTarget.classList.add("hidden")
-        this.pauseButtonContainerTarget.classList.remove("translate-y-[calc(100%+6rem)]")
+        this.pauseButtonContainerTarget.classList.remove("translate-y-[calc(100%+7rem)]")
         break;
       case STATUS.ENDED:
         // 保存確認モーダルを表示する
@@ -196,7 +196,7 @@ export default class extends Controller {
     this.transitionEvents = new AbortController();
 
     if(!this.maplibreTopContainer){
-      this.maplibreTopContainer = document.querySelector(".maplibregl-ctrl-group")
+      this.maplibreTopContainer = document.querySelector(".maplibregl-ctrl-top-right")
     }
 
     this.maplibreTopContainer.classList.add("transition-opacity", "duration-500", "opacity-0")
@@ -211,7 +211,7 @@ export default class extends Controller {
     this.rightRecordingButtonContainerTarget.classList.remove("translate-x-[calc(100%+8px)]")
 
     if(this.maplibreTopContainer){
-      this.maplibreTopContainer = document.querySelector(".maplibregl-ctrl-group")
+      this.maplibreTopContainer = document.querySelector(".maplibregl-ctrl-top-right")
     }
     this.maplibreTopContainer.classList.remove("hidden");
     // this.maplibreTopContainer.removeEventListener("transitionend", this._handleTransitionEnd);
@@ -244,7 +244,7 @@ export default class extends Controller {
   // 一定時間後アイコンを隠す
   setHiddenTimer(){
     if(!this.maplibreTopContainer){
-      this.maplibreTopContainer = document.querySelector(".maplibregl-ctrl-group");
+      this.maplibreTopContainer = document.querySelector(".maplibregl-ctrl-top-right");
     }
 
     clearTimeout(this.hiddenTimerId);
@@ -332,9 +332,17 @@ export default class extends Controller {
     form.requestSubmit()
   }
 
+  // geolocateボタンを起動
   geolocateTrigger(){
     if(this.hasMapOutlet){
       this.mapOutlet.geolocateTrigger();
+    }
+  }
+
+  // 現在地追従にして、現在地に移動(ズーム18)
+  jumpToCurrentLocation(){
+    if(this.hasMapOutlet){
+      this.mapOutlet.jumpToCurrentLocation();
     }
   }
 

--- a/app/javascript/lib/geocoder_api.js
+++ b/app/javascript/lib/geocoder_api.js
@@ -118,7 +118,7 @@ function makeMaplibreFeature(feature) {
     if (props.distance >= 1000) {
       distanceText = `${(props.distance / 1000).toFixed(1)}km`;
     } else {
-      distanceText = `${props.distance}m`;
+      distanceText = `${Math.round(props.distance)}m`;
     }
   }
 

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -75,7 +75,7 @@
 
         <%# 現在地ボタン %>
         <%= tag.button type: "button",
-          data: { action: "click->ui#geolocateTrigger" },
+          data: { action: "click->ui#jumpToCurrentLocation" },
           class: "btn btn-primary bg-yellow-400/80 text-black p-3 rounded-full shadow-lg hover:bg-yellow-500/80 active:scale-95 transition" do %>
           <%= lucide_icon('locate') %>
         <% end %>
@@ -133,7 +133,7 @@
       </div>
 
       <%# 下側一時停止ボタンコンテナ %>
-      <div class="absolute bottom-full left-1/2 -translate-x-1/2 pr-4 mb-3 pointer-events-auto duration-500 translate-y-[calc(100%+6rem)]" data-ui-target="pauseButtonContainer">
+      <div class="absolute bottom-full left-1/2 -translate-x-1/2 pr-4 mb-3 pointer-events-auto duration-500 translate-y-[calc(100%+7rem)]" data-ui-target="pauseButtonContainer">
 
         <%# 停止ボタン %>
       <div id="end-trip-button-container"></div>
@@ -158,8 +158,8 @@
 
     <%# ▼▼▼ タブバーエリア ▼▼▼ %>
     <% if show_tab_bar? %>
-      <div class="mx-auto max-w-md px-4 pointer-events-auto transition-transform duration-500 pb-4" data-ui-target="bottomSheet">
-        <div class="bg-white/20 backdrop-blur-sm rounded-2xl shadow-lg px-6 py-3">
+      <div class="mx-auto max-w-md px-4 pointer-events-none transition-transform duration-500 pb-4" data-ui-target="bottomSheet">
+        <div class="bg-white/20 backdrop-blur-sm pointer-events-auto rounded-2xl shadow-lg px-6 py-3 mb-4">
           <nav class="flex">
             <%= link_to root_path, class: tab_class(root_path) do %>
               <%= lucide_icon('map') %>

--- a/app/views/trips/_destination_ui.html.erb
+++ b/app/views/trips/_destination_ui.html.erb
@@ -1,0 +1,78 @@
+<div class="space-y-2" data-controller="destination-search" data-destination-search-map-outlet="#main-map">
+
+  <%# 目的地の距離と方角 %>
+  <div class="flex items-center gap-2">
+
+    <%# 左: 検索ボタン %>
+    <%= tag.button type: "button",
+      data: { action: "click->destination-search#toggleSearch" },
+      class: "btn btn-primary shrink-0 bg-orange-200/80 hover:bg-orange-300/80 text-black p-3 rounded-full shadow-lg active:scale-95 transition" do %>
+      <%= lucide_icon('search') %>
+    <% end %>
+
+    <%# 右: 目的地表示 %>
+    <button
+      type="button"
+      class="hidden flex-1 rounded-2xl bg-gray-100/50 backdrop-blur-md shadow-lg ring-1 ring-black/5 text-left px-3 py-2"
+      data-action="click->destination-search#toggleList"
+      data-destination-search-target="destinationInfo"
+    >
+      <div class="flex items-center justify-between gap-3">
+        <div class="min-w-0 flex flex-col justify-between">
+          <div class="text-[11px] font-bold text-gray-500 leading-none">
+            次の目的地
+          </div>
+          <div class="truncate text-sm font-bold text-gray-800 leading-none mt-1" data-destination-search-target="destinationName">
+          </div>
+        </div>
+
+        <div class="shrink-0 flex items-center justify-center gap-3">
+          <div class="text-xs font-bold text-gray-700 leading-none mt-1" data-destination-search-target="destinationDistance">
+          </div>
+          <div class="bg-orange-100 rounded-full">
+            <div class="text-red-500 font-bold leading-none p-2 transition-transform duration-200" data-destination-search-target="destinationDirection">
+              <%= lucide_icon "navigation-2", class: "w-8 h-8 fill-current" %>
+            </div>
+          </div>
+        </div>
+      </div>
+    </button>
+
+  </div>
+
+  <%# 検索パネル %>
+  <div class="hidden rounded-2xl bg-gray-100/50 backdrop-blur-md shadow-lg ring-1 ring-black/5 overflow-hidden" data-destination-search-target="searchPanel">
+    <form class="flex items-center gap-2 border-b border-white/40 px-3 py-3" data-action="submit->destination-search#search">
+      <input
+        type="text"
+        aria-label="目的地を検索"
+        placeholder="目的地を検索"
+        class="w-full bg-transparent text-sm text-gray-800 outline-none placeholder:text-gray-400"
+        data-destination-search-target="input"
+      >
+      <button type="button" class="text-gray-400 hidden"
+        data-action="click->destination-search#clearSearchAll"
+        data-destination-search-target="clearSearchButton"
+      >
+        <%= lucide_icon("x", class: "w-5 h-5") %>
+      </button>
+      <button type="submit" class="text-gray-500">
+        <span data-destination-search-target="searchIcon">
+          <%= lucide_icon("search", class: "w-5 h-5") %>
+        </span>
+        <span class="hidden" data-destination-search-target="loadingIcon">
+          <%= lucide_icon("loader-circle", class: "w-5 h-5 animate-spin") %>
+        </span>
+      </button>
+    </form>
+
+    <ul class="space-y-1 overflow-y-auto px-2 py-2 empty:py-0" data-destination-search-target="results"></ul>
+  </div>
+
+  <%# 目的地リスト %>
+  <div class="hidden rounded-2xl bg-gray-100/10 backdrop-blur-md shadow-lg ring-1 ring-black/5 p-2"
+        data-destination-search-target="listPanel">
+    <ul class="space-y-2" data-destination-search-target="list">
+    </ul>
+  </div>
+</div>

--- a/app/views/trips/new.html.erb
+++ b/app/views/trips/new.html.erb
@@ -5,7 +5,17 @@
     data-map-posts-outlet="#posts"
     class="absolute inset-0 h-full w-full"
     data-maptiler-key="<%= Rails.application.credentials.dig(:maptiler, :api_key) %>">
+
+    <%# 地図を覆うオーバーレイ要素 %>
     <div class="fixed bg-white inset-0 z-20 transition-opacity duration-1000 opacity-100" data-map-target="mapOverlay"></div>
+
+    <%# 目的地表示部分 %>
+    <div class="absolute top-0 left-0 z-10 p-3 pointer-events-none mr-11">
+      <div class="w-[min(24rem,calc(100vw-1.5rem-2.5rem))] pointer-events-auto">
+        <%= render "trips/destination_ui" %>
+      </div>
+    </div>
+
   </div>
 </div>
 <% if cookies[:terms_accepted] != "true" && cookies[:tutorials_end] != "true" && !user_signed_in? %>


### PR DESCRIPTION
## issue
- close: #146 
- 関連issue:
  - #142 

## 実装内容
- 自作目的地検索UI実装
- StyleJsonを取得できなかったときのフォールバックを実装
- StyleJsonをconstructorにキャッシュとして保持しておくよう実装
- attributionの位置を変更
- 自作の現在地ボタンをズームレベルが18になるように変更
- mapの初期化時にawaitで動作が止まってしまうのを別の関数に切り出して呼び出すことにより解消

## issueとの差分
- 目的地以外にも微修正を追加

## 動作確認方法
- 実際にブラウザで動作を確認
