### PR TITLE
新ドメインへのリダイレクトの修正+微修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,17 +1,15 @@
 class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
-  before_action :ensure_domain
-  before_action :refresh_session_expiration, :set_back_url
+  before_action :redirect_old_render_domain, if: -> { request.host == "white-map.onrender.com" }
+  before_action :set_initial_cookies, if: -> { user_signed_in? }
+  before_action :set_back_url
 
   private
 
-  def refresh_session_expiration
-    if user_signed_in?
-      current_user
-      cookies.permanent[:tutorials_end] = "true"
-      cookies.permanent[:terms_accepted] = "true"
-    end
+  def set_initial_cookies
+    cookies.permanent[:tutorials_end] = "true"
+    cookies.permanent[:terms_accepted] = "true"
   end
 
   def set_back_url
@@ -49,9 +47,12 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  def ensure_domain
-    if request.host == "white-map.onrender.com"
-      redirect_to "https://shiroichizu.app#{request.fullpath}", status: :moved_permanently
+  def redirect_old_render_domain
+    old_host = "white-map.onrender.com"
+    new_host = "shiroichizu.app"
+
+    if request.host == old_host
+      redirect_to "https://#{new_host}#{request.fullpath}", allow_other_host: true, status: :moved_permanently
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,7 +34,7 @@ class User < ApplicationRecord
   end
 
   def remember_expires_at
-    time = remember_created_at || Time.now.utc
+    time = Time.current
 
     case role
     when "guest"

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -170,6 +170,8 @@ Devise.setup do |config|
   config.expire_all_remember_me_on_sign_out = true
 
   # If true, extends the user's remember period when remembered via cookie.
+
+  # cookieの有効期限を更新する
   config.extend_remember_period = true
 
   # Options to be passed to the created cookie. For instance, you can set


### PR DESCRIPTION
- 新ドメインへのリダイレクト処理が失敗していたので修正
- allow_other_host: trueをつけて、実際に動作するのか検証済み
- remember_user_tokenのexpiresの更新部分にバグがあったので、現在の日時で更新されるように修正
- current_userを呼ばずにuser_signed_in?でもremember_user_tokenのexpiresが更新されると判明したので、refresh_session_expirationの名前と中身を修正