### PR TITLE
デプロイエラーのため、修正

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class Users::SessionsController < Devise::SessionsController
-  skip_before_action :refresh_session_expiration, only: [ :new, :create ]
   # before_action :configure_sign_in_params, only: [:create]
 
   # GET /resource/sign_in


### PR DESCRIPTION
- sessions_controller.rbのskip_before_action :refresh_session_expiration, only: [ :new, :create ]でエラー
- refresh_session_expirationのメソッド名を変更していたため発生
- refresh_session_expirationは機能と名前が変わっているため、不要と判断し、該当行を削除