### PR TITLE
Feature/164 add pmtiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@
 /vendor/bundle
 /.vscode
 .env
+
+r2/

--- a/app/javascript/controllers/base_map_controller.js
+++ b/app/javascript/controllers/base_map_controller.js
@@ -4,6 +4,7 @@ import 'maplibre-gl/dist/maplibre-gl.css'
 import ngeohash from 'ngeohash';
 import { get } from "@rails/request.js"
 import * as turf from "@turf/turf"
+import { Protocol } from "pmtiles";
 
 // 定数定義
 const INITIAL_ZOOM_LEVEL = 17;    // 初期のズームレベル
@@ -65,6 +66,10 @@ export default class extends Controller {
   async initializeMap(center){
     if (!this.ac) return;
 
+    // プロトコル登録
+    const protocol = new Protocol();
+    maplibregl.addProtocol("pmtiles", protocol.tile);
+
     const signal = this.ac.signal;
 
     try {
@@ -99,16 +104,10 @@ export default class extends Controller {
       return structuredClone(this.constructor.styleJsonCache);
     }
 
-    let apiKey = null;
-
-    if(DEBUG_MODE) {
-      apiKey = "test";
-    } else {
-      apiKey = this.element.dataset.maptilerKey;
-    }
+    const styleUrl = this.element.dataset.styleUrl;
 
     try {
-      const res = await fetch(`https://api.maptiler.com/maps/jp-mierune-dark/style.json?key=${apiKey}`, { signal: signal });
+      const res = await fetch(styleUrl, { signal: signal });
       if(!res.ok) throw new Error(`fetch失敗: ${res.status}`);
 
       const styleJson = await res.json();
@@ -123,7 +122,6 @@ export default class extends Controller {
     }
   }
 
-  // 自前のフォールバックスタイル
   getFallbackStyle() {
     return {
       version: 8,

--- a/app/javascript/controllers/history_map_controller.js
+++ b/app/javascript/controllers/history_map_controller.js
@@ -32,17 +32,17 @@ export default class extends BaseMapController {
 
     // 非表示にする地図上の情報
     const toHide = [
-      "Restaurant and shop",
-      "Store and mall",
-      "Pub",
-      "Hotel",
-      "Generic POI",
-      "Generic POI 11",
-      "Major POI",
-      "Doctor",
-      "Parking",
-      "Government",
-      "Golf pitch",
+      // "Restaurant and shop",
+      // "Store and mall",
+      // "Pub",
+      // "Hotel",
+      // "Generic POI",
+      // "Generic POI 11",
+      // "Major POI",
+      // "Doctor",
+      // "Parking",
+      // "Government",
+      // "Golf pitch",
     ];
 
     // 地図の読み込みが終わった後に実行
@@ -57,6 +57,9 @@ export default class extends BaseMapController {
       });
 
       this.executeFogClearing();
+
+      this.initRevealedAreaLayer();
+      this.updateRevealedArea();
 
       this.addMarkers();
 
@@ -133,11 +136,66 @@ export default class extends BaseMapController {
         type: "fill",
         source: 'fog',
         paint: {
-          "fill-color": "#ffffff",
-          "fill-opacity": 0.3,
+          "fill-color": "#f2eee8",
+          "fill-opacity": 0.55,
           'fill-antialias': false,
         }
       });
     }
+  }
+
+  initRevealedAreaLayer() {
+    if (!this.map.getSource('revealed-area')) {
+      this.map.addSource('revealed-area', {
+        type: 'geojson',
+        data: this.cumulativeFeature || turf.featureCollection([])
+      });
+    }
+
+    // ふわっとした外側の光
+    if (!this.map.getLayer('revealed-outline-glow')) {
+      this.map.addLayer({
+        id: 'revealed-outline-glow',
+        type: 'line',
+        source: 'revealed-area',
+        paint: {
+          'line-color': '#8b6b4a',
+          'line-opacity': 0.1,
+          'line-width': [
+            'interpolate', ['linear'], ['zoom'],
+            10, 2,
+            14, 4,
+            17, 6
+          ],
+          'line-blur': 3
+        }
+      });
+    }
+
+    // くっきりした境界線
+    if (!this.map.getLayer('revealed-outline')) {
+      this.map.addLayer({
+        id: 'revealed-outline',
+        type: 'line',
+        source: 'revealed-area',
+        paint: {
+          'line-color': '#ad8d6c',
+          'line-opacity': 0.5,
+          'line-width': [
+            'interpolate', ['linear'], ['zoom'],
+            10, 1,
+            14, 1,
+            17, 2
+          ]
+        }
+      });
+    }
+  }
+
+  updateRevealedArea() {
+    const source = this.map.getSource('revealed-area');
+    if (!source) return;
+
+    source.setData(this.cumulativeFeature || turf.featureCollection([]));
   }
 }

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -197,17 +197,17 @@ export default class extends BaseMapController {
   setupMapLoadEvents() {
     // 非表示にする地図上の情報
     const toHide = [
-      "Restaurant and shop",
-      "Store and mall",
-      "Pub",
-      "Hotel",
-      "Generic POI",
-      "Generic POI 11",
-      "Major POI",
-      "Doctor",
-      "Parking",
-      "Government",
-      "Golf pitch",
+      // "Restaurant and shop",
+      // "Store and mall",
+      // "Pub",
+      // "Hotel",
+      // "Generic POI",
+      // "Generic POI 11",
+      // "Major POI",
+      // "Doctor",
+      // "Parking",
+      // "Government",
+      // "Golf pitch",
     ];
 
     // 地図の読み込みが終わった後に実行

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -34,6 +34,13 @@
           <% end %>
         <% end %>
 
+        <%# 現在地ボタン %>
+        <%= tag.button type: "button",
+          data: { action: "click->ui#jumpToCurrentLocation" },
+          class: "btn btn-primary bg-yellow-400/80 text-black p-3 rounded-full shadow-lg hover:bg-yellow-500/80 active:scale-95 transition" do %>
+          <%= lucide_icon('locate') %>
+        <% end %>
+
         <%# 累計地図表示ボタン %>
         <div class="flex flex-col">
 

--- a/app/views/trips/_destination_ui.html.erb
+++ b/app/views/trips/_destination_ui.html.erb
@@ -17,7 +17,7 @@
     <%# 右: 目的地表示 %>
     <button
       type="button"
-      class="hidden flex-1 rounded-2xl bg-gray-100/50 backdrop-blur-md shadow-lg ring-1 ring-black/5 text-left px-3 py-2"
+      class="hidden flex-1 rounded-2xl bg-gray-100/50 backdrop-blur-md w-[min(24rem,calc(100vw-1.5rem-2.5rem))] shadow-lg ring-1 ring-black/5 text-left px-3 py-2"
       data-action="click->destination-search#toggleList"
       data-destination-search-target="destinationInfo"
     >
@@ -26,7 +26,7 @@
           <div class="text-[11px] font-bold text-gray-500 leading-none">
             次の目的地
           </div>
-          <div class="truncate text-sm font-bold text-gray-800 leading-none mt-1" data-destination-search-target="destinationName">
+          <div class="truncate text-[11px] font-bold text-gray-800 leading-none mt-1" data-destination-search-target="destinationName">
           </div>
         </div>
 

--- a/app/views/trips/new.html.erb
+++ b/app/views/trips/new.html.erb
@@ -4,7 +4,7 @@
     data-map-ui-outlet="#ui"
     data-map-posts-outlet="#posts"
     class="absolute inset-0 h-full w-full"
-    data-maptiler-key="<%= ENV.fetch("MAPTILER_API_KEY") %>">
+    data-style-url="<%= ENV.fetch("STYLE_URL") %>">
 
     <%# 地図を覆うオーバーレイ要素 %>
     <div class="fixed inset-0 z-20 transition-opacity duration-1000 opacity-100 animate-fog-twinkle" data-map-target="mapOverlay">

--- a/app/views/trips/show.html.erb
+++ b/app/views/trips/show.html.erb
@@ -33,7 +33,7 @@
       data-history-map-ui-outlet="#ui"
       data-history-map-posts-outlet="#posts"
       class="absolute inset-0 h-full w-full"
-      data-maptiler-key="<%= ENV.fetch("MAPTILER_API_KEY") %>"
+      data-style-url="<%= ENV.fetch("STYLE_URL") %>"
       data-history-map-longitude-value="<%= @first_footprint&.longitude %>"
       data-history-map-latitude-value="<%= @first_footprint&.latitude %>"
       data-history-map-visited-geohashes-value="<%= @visited_geohashes.to_json %>"

--- a/licenses/NotoSans-OFL.txt
+++ b/licenses/NotoSans-OFL.txt
@@ -1,0 +1,93 @@
+Copyright 2022 The Noto Project Authors (https://github.com/notofonts)
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is copied below, and is also available with a FAQ at:
+https://scripts.sil.org/OFL
+
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded, 
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply
+to any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as
+distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to a
+new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components,
+in Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the corresponding
+Copyright Holder. This restriction only applies to the primary font name as
+presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created
+using the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "geolib": "^3.3.4",
     "maplibre-gl": "^5.15.0",
     "ngeohash": "^0.6.3",
+    "pmtiles": "^4.4.1",
     "swiper": "^12.0.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1872,6 +1872,11 @@ fast-deep-equal@^3.1.3:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
+fflate@^0.8.2:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/fflate/-/fflate-0.8.2.tgz#fc8631f5347812ad6028bbe4a2308b2792aa1dea"
+  integrity sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==
+
 fuzzy@^0.1.1:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/fuzzy/-/fuzzy-0.1.3.tgz#4c76ec2ff0ac1a36a9dccf9a00df8623078d4ed8"
@@ -1986,6 +1991,13 @@ pbf@^4.0.1:
   integrity sha512-SuLdBvS42z33m8ejRbInMapQe8n0D3vN/Xd5fmWM3tufNgRQFBpaW2YVJxQZV4iPNqb0vEFvssMEo5w9c6BTIA==
   dependencies:
     resolve-protobuf-schema "^2.1.0"
+
+pmtiles@^4.4.1:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/pmtiles/-/pmtiles-4.4.1.tgz#11ecb2a01453ba7c0ce88027e15f768aba18913b"
+  integrity sha512-5oTeQc/yX/ft1evbpIlnoCZugQuug/iYIAj/ZTqIqzdGek4uZEho99En890EE6NOSI3JTI3IG8R7r8+SltphxA==
+  dependencies:
+    fflate "^0.8.2"
 
 point-in-polygon-hao@^1.1.0:
   version "1.2.4"


### PR DESCRIPTION
## issue
- close: #164 

## 実装内容
- pmtilesを自前のR2サーバーに配置
- 自前のpmtilesから地図タイルを取得するよう実装
- タイルのデザインが変わったことにより、過去の地図の見た目がわかりづらくなっていたので微修正

## issueとの差分
- デザイン修正を追加

## 動作確認方法
- ブラウザで実際に地図が表示されるのか確認

## 補足
- 自前ファイルはキャッシュが効くよう設定してあるので、style.jsonを更新するときは名前を変更すること
