### PR TITLE
image loader 修正

### DIFF
--- a/app/javascript/controllers/image_loader_controller.js
+++ b/app/javascript/controllers/image_loader_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
+import * as Sentry from "@sentry/browser"
 
 // Connects to data-controller="image-loader"
 export default class extends Controller {
@@ -8,15 +9,57 @@ export default class extends Controller {
   ]
 
   connect() {
+    this.retried = false; // 画像再読み込みフラグをオフでセット
   }
 
+  // 画像ロード完了後
   loaded() {
     this.imageTarget.classList.remove("opacity-0")
     this.placeholderTarget.classList.add("hidden")
   }
 
+  // 画像ロード失敗時
   error() {
-    this.placeholderTarget.textContent = "画像を表示できませんでした"
-    this.placeholderTarget.classList.remove("animate-pulse")
+    const originalSrc = this.imageTarget.getAttribute("src") || null // 画像へのリダイレクトリンクを取得
+
+    if (!this.retried) {
+      this.retried = true
+      this.imageTarget.setAttribute("src", "")
+
+      requestAnimationFrame(() => {
+        this.imageTarget.setAttribute("src", originalSrc) // URLを再セットして画像を再読み込み
+      })
+      return
+    }
+
+    if (Sentry.getCurrentHub().getClient()) {
+      Sentry.withScope((scope) => {
+        scope.setLevel("warning")
+        scope.setTag("feature", "image_loader")
+        scope.setTag("event_type", "image_load_error")
+        scope.setTag("retried", "true")
+
+        scope.setContext("image_loader", {
+          src: originalSrc,
+          currentSrc: this.imageTarget.currentSrc || null,
+          alt: this.imageTarget.getAttribute("alt") || null,
+          complete: this.imageTarget.complete,
+          naturalWidth: this.imageTarget.naturalWidth || 0,
+          naturalHeight: this.imageTarget.naturalHeight || 0
+        })
+
+        Sentry.captureMessage("画像読み込みに失敗しました")
+      })
+    }
+
+    this.placeholderTarget.classList.remove("opacity-0")
+    this.placeholderTarget.innerHTML = `
+      <span
+        class="block text-center leading-tight text-gray-500 font-medium px-2 break-words"
+        style="font-size: clamp(10px, 9cqw, 14px);"
+      >
+        画像を表示できませんでした
+      </span>
+    `
   }
 }

--- a/app/views/posts/preview.turbo_stream.erb
+++ b/app/views/posts/preview.turbo_stream.erb
@@ -95,10 +95,10 @@
 
               <%# --- 画像が複数ある場合 --- %>
               <% else %>
-                <div class="grid grid-cols-2 gap-1 w-full  h-full min-h-0  rounded-xl overflow-hidden">
+                <div class="grid grid-cols-2 gap-1 w-full min-h-0  rounded-xl overflow-hidden">
                   <% @post.images.first(4).each_with_index do |image, index| %>
-                    <div class="relative w-full aspect-[4/3] max-h-[18vh] bg-gray-200" data-controller="image-loader" style="container-type: inline-size;">
-                      <div class="absolute inset-0 flex items-center justify-center transition-opacity" data-image-loader-target="placeholder">
+                    <div class="relative w-full aspect-[4/3] max-h-[18vh]" data-controller="image-loader" style="container-type: inline-size;">
+                      <div class="absolute inset-0 flex items-center justify-center transition-opacity px-1 overflow-hidden" data-image-loader-target="placeholder">
                         <div class="w-10 h-10 border-2 border-gray-200 border-t-gray-500 rounded-full animate-spin"></div>
                       </div>
                       <%= image_tag image.variant(:thumb), loading: "lazy",


### PR DESCRIPTION
## issue
- close: #168 

## 実装内容
- image loaderで画像表示失敗時に一度だけ画像を再読み込みするように実装
- image loaderで画像表示失敗時にinnerHTMLで要素を追加して、文字のサイズが可変するように実装
- image loaderの画像表示失敗時にSentryで情報を送信するように実装

## issueとの差分
- Sentry部分を追加

## 動作確認方法
- 一時的に画像表示時にエラーを発生するようにして、画像が再読み込みされるのかブラウザにて確認
- 一時的に画像表示時にエラーを発生するようにして、画像表示失敗メッセージが意図している動作をするのかブラウザにて確認