### PR TITLE
postsバリデーション設定完了

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -46,3 +46,10 @@
 # Ignore Docker-related files
 /.dockerignore
 /Dockerfile*
+
+.DS_Store
+/vendor/bundle
+/.vscode
+.env
+
+r2/

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -49,7 +49,7 @@ class ApplicationController < ActionController::Base
   end
 
   def redirect_old_render_domain
-    old_host = "white-map.onrender.com"
+    old_host = "shiroichizu.fly.dev"
     new_host = "shiroichizu.app"
 
     if request.host == old_host

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -21,9 +21,10 @@ if (!window.hasMacScrollbarEnhancer) {
 
 const sentryDsn = document.querySelector(`meta[name="sentry-dsn"]`)?.content
 
-if (location.hostname !== "localhost") {
+if(location.hostname !== "localhost"){
   Sentry.init({
     dsn: sentryDsn,
+    environment: "production",
     sendDefaultPii: false, // 個人情報を送らない
     tracesSampleRate: 0,
     beforeSend(event) {

--- a/app/javascript/controllers/error_controller.js
+++ b/app/javascript/controllers/error_controller.js
@@ -12,6 +12,6 @@ export default class extends Controller {
       this.element.addEventListener("transitionend", () => {
         this.element.remove();
       }, { once: true });
-    }, 1500)
+    }, 2300)
   }
 }

--- a/app/javascript/controllers/image_loader_controller.js
+++ b/app/javascript/controllers/image_loader_controller.js
@@ -32,25 +32,24 @@ export default class extends Controller {
       return
     }
 
-    if (Sentry.getCurrentHub().getClient()) {
-      Sentry.withScope((scope) => {
-        scope.setLevel("warning")
-        scope.setTag("feature", "image_loader")
-        scope.setTag("event_type", "image_load_error")
-        scope.setTag("retried", "true")
 
-        scope.setContext("image_loader", {
-          src: originalSrc,
-          currentSrc: this.imageTarget.currentSrc || null,
-          alt: this.imageTarget.getAttribute("alt") || null,
-          complete: this.imageTarget.complete,
-          naturalWidth: this.imageTarget.naturalWidth || 0,
-          naturalHeight: this.imageTarget.naturalHeight || 0
-        })
+    Sentry.withScope((scope) => {
+      scope.setLevel("warning")
+      scope.setTag("feature", "image_loader")
+      scope.setTag("event_type", "image_load_error")
+      scope.setTag("retried", "true")
 
-        Sentry.captureMessage("画像読み込みに失敗しました")
+      scope.setContext("image_loader", {
+        src: originalSrc,
+        currentSrc: this.imageTarget.currentSrc || null,
+        alt: this.imageTarget.getAttribute("alt") || null,
+        complete: this.imageTarget.complete,
+        naturalWidth: this.imageTarget.naturalWidth || 0,
+        naturalHeight: this.imageTarget.naturalHeight || 0
       })
-    }
+
+      Sentry.captureMessage("画像読み込みに失敗しました")
+    })
 
     this.placeholderTarget.classList.remove("opacity-0")
     this.placeholderTarget.innerHTML = `

--- a/app/javascript/controllers/images_compress_controller.js
+++ b/app/javascript/controllers/images_compress_controller.js
@@ -1,9 +1,11 @@
 import { Controller } from "@hotwired/stimulus"
 import Compressor from 'compressorjs'
+import * as Sentry from "@sentry/browser"
 
-const QUALITY    = 0.85;
-const MAX_WIDTH  = 1600;
-const MAX_HEIGHT = 1600;
+const QUALITY    = 0.85; // 画質 0-1
+const MAX_WIDTH  = 1600; // 最大幅
+const MAX_HEIGHT = 1600; // 最大高さ
+const MAX_IMAGES_COUNT = 6;
 
 // Connects to data-controller="images-compress"
 export default class extends Controller {
@@ -24,10 +26,11 @@ export default class extends Controller {
     return false;
   }
 
-  compress(event) {
+  async compress(event) {
     const files = Array.from(event.target.files);
     const dataTransfer = new DataTransfer();
 
+    // 添付画像がないときは、既存のファイルを保持してreturn
     if (files.length === 0) {
       if(this.currentFiles.length > 0){
         this.currentFiles.forEach(file => {
@@ -43,78 +46,138 @@ export default class extends Controller {
       if (!file.type.startsWith('image/')){
         alert('画像ファイルを選択してください')
         event.target.value = '';
+        if(this.currentFiles.length > 0){
+          this.currentFiles.forEach(file => {
+            dataTransfer.items.add(file);
+          })
+          this.inputTarget.files = dataTransfer.files;
+        }
         return;
       }
     }
 
-    // Compressor.jsで圧縮
-    files.forEach(file => {
-      this.compressImages(file, dataTransfer);
+    // 画像枚数制限
+    if (files.length + this.currentFiles.length > MAX_IMAGES_COUNT){
+      alert(`画像の添付は${MAX_IMAGES_COUNT}枚までとなっています`);
+      event.target.value = '';
+      if(this.currentFiles.length > 0){
+        this.currentFiles.forEach(file => {
+          dataTransfer.items.add(file);
+        })
+        this.inputTarget.files = dataTransfer.files;
+      }
+      return;
+    }
+
+    // 画像を圧縮
+    const results = await Promise.allSettled(
+      files.map(file => this.compressImages(file))
+    )
+
+    const successItems = results.filter(r => r.status === "fulfilled").map(r => r.value); // 圧縮が成功した画像で新たな配列を作成
+    const failedItems = results.filter(r => r.status === "rejected").map(r => r.reason); // 圧縮が失敗した画像で新たな配列を作成
+
+    // 圧縮成功画像をcurrentFilesに追加
+    successItems.forEach(file => {
+      this.currentFiles.push(file);
     })
+
+    // currentFilesで送信用データを作成
+    this.currentFiles.forEach(file => {
+      dataTransfer.items.add(file);
+    })
+
+    this.inputTarget.files = dataTransfer.files; // inputに送信用データをセット
+    this.renderPreview(successItems); // 追加した画像を画面に表示
+
+    if (failedItems.length > 0) {
+      alert("一部の画像の圧縮に失敗しました")
+    }
   }
 
-  compressImages(file, dataTransfer){
+  compressImages(file){
     const targetMimeType = this.isWebpSupported ? 'image/webp' : 'image/jpeg';
     const targetExtension = this.isWebpSupported ? '.webp' : '.jpeg';
 
-    new Compressor(file, {
-      quality: QUALITY, // 画質 0-1
-      maxWidth: MAX_WIDTH, // 最大幅
-      maxHeight: MAX_HEIGHT, // 最大高さ
-      mimeType: targetMimeType,
-      success: (result) => {
-        // 圧縮されたresultで元のinputの中身をすり替える
-        const uniqueId = Date.now().toString(36) + Math.random().toString(36).slice(2, 7); // ランダムなIDを生成
-        const newFileName = file.name.replace(/\.[^/.]+$/, "") + targetExtension;
-        const newFile = new File([result], newFileName, { type: targetMimeType });
-        newFile.uniqueId = uniqueId;
-        console.log(uniqueId);
+    return new Promise((resolve, reject) => {
+      new Compressor(file, {
+        quality: QUALITY,
+        maxWidth: MAX_WIDTH,
+        maxHeight: MAX_HEIGHT,
+        mimeType: targetMimeType,
+        success: (result) => {
+          const uniqueId = Date.now().toString(36) + Math.random().toString(36).slice(2, 7); // ランダムなIDを生成
+          const newFileName = `${uniqueId}${targetExtension}`;
+          const newFile = new File([result], newFileName, { type: targetMimeType });
+          newFile.uniqueId = uniqueId; // IDを付与
 
-        this.currentFiles.push(newFile);
-        dataTransfer.items.add(newFile);
-        this.inputTarget.files = dataTransfer.files;
+          resolve(newFile);
 
-        // デフォルトアイコンを非表示
-        if (this.hasDefaultIconTarget) {
-          this.defaultIconTarget.classList.add('hidden');
+          console.log(`圧縮成功(${targetMimeType}): ${(result.size / 1024).toFixed(2)} KB`);
+        },
+        error: (err) => {
+          console.log("画像圧縮エラー:", err.message);
+
+          Sentry.withScope((scope) => {
+            scope.setLevel("warning")
+            scope.setTag("feature", "image_compress")
+            scope.setTag("event_type", "image_compress_error")
+
+            scope.setContext("compress", {
+              original_name: file.name,
+              original_type: file.type,
+              original_size: file.size,
+              target_mime_type: targetMimeType,
+              webp_supported: this.isWebpSupported
+            })
+            Sentry.captureException(err)
+          })
+
+          reject(err);
         }
-
-        // 選んだ画像を画面に表示
-        if (this.hasPreviewTarget) {
-          const url = URL.createObjectURL(result);
-
-          const div = document.createElement("div");
-          div.className = "shrink-0 w-40 h-40 bg-gray-100 rounded-lg flex items-center justify-center snap-center relative";
-
-          const img = document.createElement("img");
-          img.src = url;
-          img.className = "w-full h-full object-cover rounded-lg";
-
-          const button = document.createElement("button");
-          button.type = "button";
-          button.className = "absolute -top-0 -right-0 rounded-full text-white hover:text-gray-400 shadow border border-gray-200 p-2 z-10 w-8 h-8 flex items-center justify-center opacity-80 bg-gray-600";
-
-          button.setAttribute("data-action", "click->images-compress#removePreview");
-          button.setAttribute("data-file-id", uniqueId);
-
-          button.innerHTML = `
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4">
-              <path d="M18 6 6 18"></path>
-              <path d="m6 6 12 12"></path>
-            </svg>
-          `;
-
-          div.appendChild(img);
-          div.appendChild(button);
-          this.previewTarget.appendChild(div);
-        }
-
-        console.log(`圧縮成功(${targetMimeType}): ${(result.size / 1024).toFixed(2)} KB`);
-      },
-      error(err){
-        console.log("画像圧縮エラー:", err.message);
-      }
+      })
     })
+  }
+
+  renderPreview(successItems){
+    if(successItems.length === 0) return;
+
+    // デフォルトアイコンを非表示
+    if (this.hasDefaultIconTarget) {
+      this.defaultIconTarget.classList.add('hidden');
+    }
+
+    if (this.hasPreviewTarget) {
+      successItems.forEach(file => {
+        // 画像を画面に表示
+        const url = URL.createObjectURL(file);
+
+        const div = document.createElement("div");
+        div.className = "aspect-square w-full rounded-lg flex items-center justify-center relative overflow-hidden";
+
+        const img = document.createElement("img");
+        img.src = url;
+        img.className = "w-full h-full object-cover rounded-lg";
+
+        const button = document.createElement("button");
+        button.type = "button";
+        button.className = "absolute -top-0 -right-0 rounded-full text-white hover:text-gray-400 shadow border border-gray-200 p-2 z-10 w-8 h-8 flex items-center justify-center opacity-80 bg-gray-600";
+
+        button.setAttribute("data-action", "click->images-compress#removePreview");
+        button.setAttribute("data-file-id", file.uniqueId);
+
+        button.innerHTML = `
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4">
+            <path d="M18 6 6 18"></path>
+            <path d="m6 6 12 12"></path>
+          </svg>
+        `;
+
+        div.appendChild(img);
+        div.appendChild(button);
+        this.previewTarget.appendChild(div);
+      });
+    }
   }
 
   // 削除ボタンを押した時の処理
@@ -122,12 +185,15 @@ export default class extends Controller {
     event.preventDefault();
     const button = event.currentTarget;
     const targetId = button.getAttribute("data-file-id"); // ターゲットのidを取得
+    const img = button.parentElement.querySelector("img");
 
     button.parentElement.remove(); // ターゲットの画像要素を削除
+    URL.revokeObjectURL(img.src) // メモリ上のBlobデータへの参照を切る
 
     // targetId以外のものだけ残す
     this.currentFiles = this.currentFiles.filter(file => file.uniqueId !== targetId);
 
+    // 残った画像を送信用に再びセットし直す
     const dataTransfer = new DataTransfer();
     this.currentFiles.forEach(file => dataTransfer.items.add(file));
     this.inputTarget.files = dataTransfer.files
@@ -135,6 +201,14 @@ export default class extends Controller {
     // デフォルトアイコンを表示
     if (this.hasDefaultIconTarget && (this.currentFiles.length === 0)) {
       this.defaultIconTarget.classList.remove('hidden');
+    }
+  }
+
+  countCheck(event){
+    if(this.currentFiles.length >= 6){
+      event.preventDefault();
+      alert("画像添付は6枚までとなっています")
+      return
     }
   }
 }

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -13,6 +13,18 @@
 #   t.index ["user_id"], name: "index_posts_on_user_id"
 
 class Post < ApplicationRecord
+  include ActionView::Helpers::NumberHelper
+
+  # 定数定義
+  MAX_IMAGES_COUNT = 6
+  MAX_BODY_LENGTH = 300
+  MAX_IMAGE_SIZE = 5.megabytes
+  ALLOWED_IMAGE_TYPES = %w[
+    image/jpeg
+    image/jpg
+    image/webp
+  ].freeze
+
   # enum 定義
   # 投稿の公開ステータス
   # 公開:0, フォロワー限定:10, 非公開:20
@@ -22,6 +34,7 @@ class Post < ApplicationRecord
   validates :user_id, :latitude, :longitude, :visibility, :visited_at, presence: true
   validate :body_or_images_presence
   validate :visited_at_cannot_be_in_the_future
+  validates :body, length: { maximum: MAX_BODY_LENGTH  }
 
   # アソシエーション定義
   belongs_to :user
@@ -30,11 +43,15 @@ class Post < ApplicationRecord
   # Active Storage設定
   has_many_attached :images do |attachable|
     # マップ用アイコン
-    attachable.variant :map_icon, resize_to_fill: [ 100, 100 ], preprocessed: true
+    attachable.variant :map_icon, resize_to_fill: [ 100, 100 ], saver: { quality: 70 }, preprocessed: true
 
     # 一覧表示用、比率維持
-    attachable.variant :thumb, resize_to_limit: [ 600, 600 ], saver: { quality: 100 }, preprocessed: true
+    attachable.variant :thumb, resize_to_limit: [ 600, 600 ], saver: { quality: 85 }, preprocessed: true
   end
+
+  validate :validate_images_size
+  validate :validate_images_count
+  validate :allow_image_type
 
   # 初期値定義
   # 開始時刻はアプリ側の時間を入れる
@@ -46,8 +63,28 @@ class Post < ApplicationRecord
 
   private
 
+  def validate_images_count
+    return unless images.attached?
+
+    if images.attachments.size > MAX_IMAGES_COUNT
+      errors.add(:images, "は#{MAX_IMAGES_COUNT}枚までです")
+    end
+  end
+
+  def validate_images_size
+    return unless images.attached?
+
+    images.each do |image|
+      if image.blob.byte_size > MAX_IMAGE_SIZE
+        errors.add(:images, "は1枚あたり#{number_to_human_size(MAX_IMAGE_SIZE)}以下にしてください")
+        break
+      end
+    end
+  end
+
   def body_or_images_presence
-    if body.blank? && images.blank?
+    normalized_body = body.to_s.strip
+    if normalized_body.blank? && !images.attached?
       errors.add(:base, "本文または画像のどちらかが必須です")
     end
   end
@@ -57,6 +94,17 @@ class Post < ApplicationRecord
 
     if visited_at > Time.current
       errors.add(:visited_at, "は未来の日時に設定できません")
+    end
+  end
+
+  def allow_image_type
+    return unless images.attached?
+
+    images.each do |image|
+      unless image.content_type&.in?(ALLOWED_IMAGE_TYPES)
+        errors.add(:images, "の形式が未対応です。再度添付し直してください")
+        break
+      end
     end
   end
 end

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -23,7 +23,7 @@
   </div>
 
   <%# --- メイン --- %>
-  <div class="flex-1 overflow-y-auto p-4 flex flex-col gap-6">
+  <div class="flex-1 overflow-y-auto p-4 flex flex-col gap-2">
 
     <%# 訪問日時入力エリア %>
     <div class="shrink-0 w-full border-b border-gray-200 pb-2">
@@ -39,10 +39,12 @@
     </div>
 
     <%# テキスト入力エリア %>
-    <div class="flex-1 min-h-[40vh] border border-gray-400 flex">
+    <div class="shrink-0 w-full border border-gray-300 rounded-2xl bg-white/80 overflow-hidden">
       <%= f.text_area :body,
-          placeholder: "地図に思いを残そう(省略可)",
-          class: "w-full flex-1 resize-none border-none outline-none focus:ring-0 text-lg placeholder-gray-300 leading-relaxed",
+          placeholder: "感じたことを、ひとこと(省略可)",
+          maxlength: 300,
+          rows: 5,
+          class: "w-full resize-none border-none outline-none text-base focus:ring-0 placeholder-gray-300 leading-relaxed p-4 overflow-y-auto",
           style: "box-shadow: none;"
       %>
     </div>
@@ -52,30 +54,30 @@
 
       <div class="flex items-center justify-center mb-4">
         <label class="bg-orange-100 text-orange-600 px-6 py-2 rounded-full font-bold text-sm hover:bg-orange-200 transition cursor-pointer">
-          写真を追加
+          写真を追加（6枚まで）
           <%= f.file_field :images,
             accept: "image/*",
             multiple: true,
             class: "hidden",
             data: {
               images_compress_target: "input",
-              action: "change->images-compress#compress"
+              action: "click->images-compress#countCheck change->images-compress#compress"
             } %>
         </label>
       </div>
 
       <div class="relative w-full">
 
-        <div data-images-compress-target="preview" class="flex gap-3 overflow-x-auto pb-4 snap-x w-full">
+        <div data-images-compress-target="preview" class="grid grid-cols-2 md:grid-cols-3 gap-3 w-full">
           <% if post.images.attached? %>
             <% post.images.each do |image| %>
-              <div class="shrink-0 w-40 h-40 bg-gray-100 rounded-lg flex items-center justify-center snap-center overflow-hidden relative">
+              <div class="aspect-square w-full rounded-lg flex items-center justify-center relative overflow-hidden">
                 <%= image_tag image, class: "w-full h-full object-cover" %>
                 <%= f.hidden_field :images, multiple: true, value: image.signed_id %>
               </div>
             <% end %>
           <% else %>
-            <div data-images-compress-target="defaultIcon" class="shrink-0 w-40 h-40 bg-gray-100 rounded-lg border-2 border-dashed border-gray-300 flex items-center justify-center snap-center">
+            <div data-images-compress-target="defaultIcon" class="aspect-square w-full bg-gray-100 rounded-lg border-2 border-dashed relative overflow-hidden border-gray-300 flex items-center justify-center">
               <span class="text-gray-400 text-sm">No Image</span>
             </div>
           <% end %>


### PR DESCRIPTION
## issue
- close: #170 

## 実装内容
- post.rbに投稿画像枚数制限のバリデーションを設定
- post.rbに文章投稿時のバリデーションを設定
- post.rbに画像の種類をチェックするバリデーションを設定
- images_compress_controller.jsに画像枚数制限でアラートを出すよう実装
- posts/_form.html.erbに画像投稿可能枚数を明記
- posts/_form.html.erbのtext_areaにmaxlength:300を設定
- 画像投稿のUIを変更
- 画像投稿エラー時にSentryにデータを送るよう実装

## issueとの差分
- UI変更部分を追加
- Sentryの部分を追加

## 動作確認方法
- ブラウザにて実際に投稿し、各種バリデーションが機能しているか確認
- 意図的にエラーを発生させて、Sentryにデータが送られるか確認

## 補足
- Sentryの実装方法が誤っていたので、修正
