### PR TITLE
avatar移行完了

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
       CLOUDFLARE_SECRET_ACCESS_KEY: "dummy"
       CLARITY_ID: "dummy"
       SENTRY_DSN: "dummy"
-      R2_ENDPOINT: "dummy"
+      R2_ENDPOINT: "https://dummy"
       CLOUDFLARE_ZONE_ID: "dummy"
       CLOUDFLARE_CACHE_PURGE_API_TOKEN: "dummy"
       R2_PUBLIC_ASSETS_HOST: "dummy"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,13 @@ jobs:
       CLOUDFLARE_SECRET_ACCESS_KEY: "dummy"
       CLARITY_ID: "dummy"
       SENTRY_DSN: "dummy"
+      R2_ENDPOINT: "dummy"
+      CLOUDFLARE_ZONE_ID: "dummy"
+      CLOUDFLARE_CACHE_PURGE_API_TOKEN: "dummy"
+      R2_PUBLIC_ASSETS_HOST: "dummy"
+      R2_PUBLIC_BUCKET: "dummy"
+      R2_PUBLIC_SECRET_ACCESS_KEY: "dummy"
+      R2_PUBLIC_ACCESS_KEY_ID: "dummy"
 
     services:
       postgres:

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,16 @@ COPY . .
 RUN bundle exec bootsnap precompile app/ lib/
 
 # Precompiling assets for production without requiring secret RAILS_MASTER_KEY
-RUN SECRET_KEY_BASE_DUMMY=1 ./bin/rails assets:precompile
+RUN AWS_EC2_METADATA_DISABLED=true \
+    SECRET_KEY_BASE_DUMMY=1 \
+    CLOUDFLARE_ACCESS_KEY_ID=dummy_for_build \
+    CLOUDFLARE_SECRET_ACCESS_KEY=dummy_for_build \
+    CLOUDFLARE_R2_BUCKET=dummy_bucket \
+    R2_PUBLIC_ACCESS_KEY_ID=dummy_for_build \
+    R2_PUBLIC_SECRET_ACCESS_KEY=dummy_for_build \
+    R2_PUBLIC_BUCKET=dummy_bucket \
+    R2_ENDPOINT=https://dummy.r2.cloudflarestorage.com \
+    ./bin/rails assets:precompile
 
 
 RUN rm -rf node_modules

--- a/Gemfile
+++ b/Gemfile
@@ -82,3 +82,5 @@ gem "http_accept_language", "~> 2.1"
 gem "bullet", "~> 8.1", group: :development
 
 gem "rack-attack", "~> 6.8"
+
+gem "faraday", "~> 2.14"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,6 +142,12 @@ GEM
     erubi (1.13.1)
     et-orbi (1.4.0)
       tzinfo
+    faraday (2.14.1)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-net_http (3.4.2)
+      net-http (~> 0.5)
     ffi (1.17.3-aarch64-linux-gnu)
     ffi (1.17.3-aarch64-linux-musl)
     ffi (1.17.3-arm-linux-gnu)
@@ -223,6 +229,8 @@ GEM
     msgpack (1.8.0)
     multi_xml (0.8.1)
       bigdecimal (>= 3.1, < 5)
+    net-http (0.9.1)
+      uri (>= 0.11.1)
     net-imap (0.5.12)
       date
       net-protocol
@@ -435,6 +443,7 @@ GEM
       unicode-emoji (~> 4.1)
     unicode-emoji (4.1.0)
     uniform_notifier (1.18.0)
+    uri (1.1.1)
     useragent (0.16.11)
     warden (1.2.9)
       rack (>= 2.0.9)
@@ -476,6 +485,7 @@ DEPENDENCIES
   capybara
   debug
   devise (~> 4.9)
+  faraday (~> 2.14)
   good_job (~> 4.14)
   http_accept_language (~> 2.1)
   image_processing (~> 1.2)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -24,21 +24,39 @@ class UsersController < ApplicationController
       return
     end
 
-    if params[:user] && params[:user][:remove_avatar] == "1"
-      @user.avatar.purge
+    uploaded_file = params.dig(:user, :avatar)
+    remove_avatar = params.dig(:user, :remove_avatar) == "1"
+
+    if uploaded_file.present? && uploaded_file.size > 500.kilobytes
+      @user.errors.add(:avatar, "のサイズが大きすぎます。不正なデータの可能性があります")
+      return respond_modal("shared/flash_and_error", locals: { object: @user }, flash_message: { alert: "保存に失敗しました" })
     end
 
-    if params[:user] && params[:user][:avatar].present?
-      uploaded_file = params[:user][:avatar]
+    old_avatar_url = current_avatar_public_url(@user)
 
-      if uploaded_file.size > 200.kilobytes
-        @user.errors.add(:avatar, "のサイズが大きすぎます。不正なデータの可能性があります")
-        return respond_modal("shared/flash_and_error", locals: { object: @user }, flash_message: { alert: "保存に失敗しました" })
+    if @user.update(profile_params.except(:avatar))
+      begin
+        if remove_avatar
+          @user.avatar.purge
+          purge_cloudflare_url(old_avatar_url)
+
+        elsif uploaded_file.present?
+          @user.avatar.attach(
+            io: uploaded_file.tempfile,
+            filename: uploaded_file.original_filename,
+            content_type: uploaded_file.content_type,
+            key: avatar_key(@user, uploaded_file)
+          )
+
+          purge_cloudflare_url(old_avatar_url)
+        end
+
+        respond_modal
+      rescue => e
+        Rails.logger.error("Avatar update failed for user=#{@user.id}: #{e.class} #{e.message}")
+        @user.errors.add(:avatar, "の保存に失敗しました")
+        respond_modal("shared/flash_and_error", locals: { object: @user }, flash_message: { alert: "保存に失敗しました" })
       end
-    end
-
-    if @user.update(profile_params)
-      respond_modal
     else
       respond_modal("shared/flash_and_error", locals: { object: @user }, flash_message: { alert: "保存に失敗しました" })
     end
@@ -53,6 +71,31 @@ class UsersController < ApplicationController
   end
 
   private
+
+  def current_avatar_public_url(user)
+    return nil unless user.avatar.attached?
+
+    key = user.avatar.blob.key
+    "#{ENV.fetch("R2_PUBLIC_ASSETS_HOST")}/#{key}"
+  end
+
+  def purge_cloudflare_url(url)
+    return if url.blank?
+
+    conn = Faraday.new(url: "https://api.cloudflare.com")
+    response = conn.post("/client/v4/zones/#{ENV.fetch("CLOUDFLARE_ZONE_ID")}/purge_cache") do |req|
+      req.headers["Authorization"] = "Bearer #{ENV.fetch("CLOUDFLARE_CACHE_PURGE_API_TOKEN")}"
+      req.headers["Content-Type"] = "application/json"
+      req.body = { files: [url] }.to_json
+    end
+
+    Rails.logger.info("Cloudflare purge response: #{response.status} #{response.body}")
+  end
+
+  def avatar_key(user, uploaded_file)
+    ext = File.extname(uploaded_file.original_filename).downcase
+    "avatars/#{user.public_uid}/#{SecureRandom.uuid}#{ext}"
+  end
 
   def record_not_unique
     Rails.logger.debug "ユニークじゃありません"

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -86,7 +86,7 @@ class UsersController < ApplicationController
     response = conn.post("/client/v4/zones/#{ENV.fetch("CLOUDFLARE_ZONE_ID")}/purge_cache") do |req|
       req.headers["Authorization"] = "Bearer #{ENV.fetch("CLOUDFLARE_CACHE_PURGE_API_TOKEN")}"
       req.headers["Content-Type"] = "application/json"
-      req.body = { files: [url] }.to_json
+      req.body = { files: [ url ] }.to_json
     end
 
     Rails.logger.info("Cloudflare purge response: #{response.status} #{response.body}")

--- a/app/helpers/avatar_helper.rb
+++ b/app/helpers/avatar_helper.rb
@@ -1,0 +1,7 @@
+module AvatarHelper
+  def avatar_url(user)
+    return unless user.avatar.attached?
+
+    "#{ENV.fetch("R2_PUBLIC_ASSETS_HOST")}/#{user.avatar.blob.key}"
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,8 @@ class User < ApplicationRecord
   before_validation :normalize_email
 
   # active storage設定
-  has_one_attached :avatar
+  has_one_attached :avatar, service: :cloudflare_public
+  # has_one_attached :avatar, service: Rails.env.production? ? :cloudflare_public : :local
 
   attr_accessor :remove_avatar
 

--- a/app/views/posts/preview.turbo_stream.erb
+++ b/app/views/posts/preview.turbo_stream.erb
@@ -20,7 +20,7 @@
 
             <%# アイコン %>
             <% if @post.user.avatar.attached? %>
-              <%= image_tag @post.user.avatar, class: "w-10 h-10 object-cover rounded-full shadow-sm" %>
+              <%= image_tag avatar_url(@post.user), class: "w-10 h-10 object-cover rounded-full shadow-sm" %>
             <% else %>
               <div class="w-10 h-10 bg-orange-400 rounded-full flex items-center justify-center shadow-sm">
                 <%= lucide_icon('user-round', class: "w-6 h-6 text-white") %>

--- a/app/views/posts/show.turbo_stream.erb
+++ b/app/views/posts/show.turbo_stream.erb
@@ -16,7 +16,7 @@
 
             <%# アイコン %>
             <% if @post.user.avatar.attached? %>
-              <%= image_tag @post.user.avatar, class: "w-10 h-10 object-cover rounded-full shadow-sm" %>
+              <%= image_tag avatar_url(@post.user), class: "w-10 h-10 object-cover rounded-full shadow-sm" %>
             <% else %>
               <div class="w-10 h-10 bg-orange-400 rounded-full flex items-center justify-center shadow-sm">
                 <%= lucide_icon('user-round', class: "w-6 h-6 text-white") %>

--- a/app/views/users/edit.turbo_stream.erb
+++ b/app/views/users/edit.turbo_stream.erb
@@ -7,7 +7,7 @@
       <% has_avatar = @user.avatar.attached? %>
 
       <%# プレビュー画像 %>
-      <%= image_tag (has_avatar ? @user.avatar : ""),
+      <%= image_tag (has_avatar ? avatar_url(@user) : ""),
             class: "w-full h-full object-cover rounded-full #{has_avatar ? '' : 'hidden'}",
             data: { avatar_compress_target: "preview" } %>
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -7,7 +7,7 @@
     <div id="user-profile" class="bg-white rounded-xl shadow-md p-4 mb-4 flex items-center">
       <% if @user.avatar.attached? %>
         <div class="w-16 h-16 rounded-full flex items-center justify-center shadow-md">
-          <%= image_tag @user.avatar, class: "w-full h-full object-cover rounded-full" %>
+          <%= image_tag avatar_url(@user), class: "w-full h-full object-cover rounded-full" %>
         </div>
       <% else %>
         <div class="w-16 h-16 bg-orange-400 rounded-full flex items-center justify-center shadow-md">
@@ -17,7 +17,6 @@
       <div class="ml-4 flex-1 flex justify-between items-center">
         <div class="text-xl font-bold text-gray-800">
           <%= @user.nickname %>
-          <%= "[管理者]" if @user.admin?%>
         </div>
         <% if current_user&.general? || current_user&.admin? %>
           <%= link_to edit_profile_path, class: "p-2 rounded-full hover:bg-gray-200", data: { turbo_stream: true } do %>

--- a/app/views/users/update.turbo_stream.erb
+++ b/app/views/users/update.turbo_stream.erb
@@ -2,7 +2,7 @@
   <div id="user-profile" class="bg-white rounded-xl shadow-md p-4 mb-4 flex items-center">
     <% if @user.avatar.attached? %>
       <div class="w-16 h-16 rounded-full flex items-center justify-center shadow-md">
-        <%= image_tag @user.avatar, class: "w-full h-full object-cover rounded-full" %>
+        <%= image_tag avatar_url(@user), class: "w-full h-full object-cover rounded-full" %>
       </div>
     <% else %>
       <div class="w-16 h-16 bg-orange-400 rounded-full flex items-center justify-center shadow-md">
@@ -13,7 +13,7 @@
       <div class="text-xl font-bold text-gray-800">
         <%= @user.nickname %>
       </div>
-      <% if current_user&.general? %>
+      <% unless current_user&.guest? %>
         <%= link_to edit_profile_path, class: "p-2 rounded-full hover:bg-gray-200", data: { turbo_stream: true } do %>
           <%= lucide_icon('square-pen', class: "text-gray-700")%>
         <% end %>

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -16,13 +16,25 @@ amazon:
 
 cloudflare:
   service: S3
-  endpoint: "https://89bd190ef8daebf81c24c61e64b27cc3.r2.cloudflarestorage.com"
+  endpoint: <%= ENV.fetch("R2_ENDPOINT") %>
   access_key_id: <%= ENV.fetch("CLOUDFLARE_ACCESS_KEY_ID") %>
   secret_access_key: <%= ENV.fetch("CLOUDFLARE_SECRET_ACCESS_KEY") %>
   region: auto
   bucket: <%= ENV.fetch("CLOUDFLARE_R2_BUCKET") %>
   request_checksum_calculation: "when_required"
   response_checksum_validation: "when_required"
+
+cloudflare_public:
+  service: S3
+  endpoint: <%= ENV.fetch("R2_ENDPOINT") %>
+  access_key_id: <%= ENV.fetch("R2_PUBLIC_ACCESS_KEY_ID") %>
+  secret_access_key: <%= ENV.fetch("R2_PUBLIC_SECRET_ACCESS_KEY") %>
+  region: auto
+  bucket: <%= ENV.fetch("R2_PUBLIC_BUCKET") %>
+  request_checksum_calculation: "when_required"
+  response_checksum_validation: "when_required"
+  upload:
+    cache_control: "public, max-age=31536000, immutable"
 
 # Remember not to checkin your GCS keyfile to a repository
 # google:

--- a/script/migrate_existing_avatars_to_public_bucket.rb
+++ b/script/migrate_existing_avatars_to_public_bucket.rb
@@ -1,0 +1,32 @@
+puts "Start avatar migration"
+
+User.joins(:avatar_attachment).find_each do |user|
+  begin
+    old_blob = user.avatar.blob
+    old_key  = old_blob.key
+
+    if old_blob.service_name == "cloudflare_public"
+      puts "skip user=#{user.id} already migrated key=#{old_key}"
+      next
+    end
+
+    ext = File.extname(old_blob.filename.to_s).downcase
+
+    old_blob.open do |file|
+      new_blob = ActiveStorage::Blob.create_and_upload!(
+        io: file,
+        filename: old_blob.filename.to_s,
+        content_type: old_blob.content_type,
+        key: "avatars/#{user.public_uid}/#{SecureRandom.uuid}#{ext}",
+        service_name: "cloudflare_public"
+      )
+
+      user.avatar.attach(new_blob)
+      puts "migrated user=#{user.id} old_key=#{old_key} new_key=#{new_blob.key}"
+    end
+  rescue => e
+    puts "failed user=#{user.id} error=#{e.class} #{e.message}"
+  end
+end
+
+puts "Done"


### PR DESCRIPTION
## issue
- close: #163 

## 実装内容
- avatar用R2バケットを作成
- avatar用Active Storage serviceを追加
- 画像アップロード時に、cache_controlを設定するよう実装
- avatarの保存先を新serviceへ切り替え
- 既存avatarを新保存先へ移行

## issueとの差分
- 特になし

## 動作確認方法
- 実際にアップロードして、画像が新しいバケットに保存されているのか確認
- curl -i "xx" でヘッダーにcacheの設定があるのか確認
- 複数curlでリクエストを送ってcacheがHITになるのか確認
