### PR TITLE
ユーザーの投稿一覧実装

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,6 +1,16 @@
 class PostsController < ApplicationController
   before_action :set_trip, only: %i[ new create select_position ]
 
+  def index
+    @posts = current_user
+                .posts
+                .includes(:trip, user: { avatar_attachment: :blob })
+                .with_attached_images
+                .order(visited_at: :desc)
+
+    MediaAccessGrantService.call(posts: @posts, cookies: cookies)
+  end
+
   def new
     return respond_modal("shared/flash_message", flash_message: { alert: "場所を選択してください" }) if params[:lat].nil? || params[:lng].nil?
 
@@ -88,10 +98,11 @@ class PostsController < ApplicationController
     end
 
     urls = media_origin_urls(@post)
+    @post_dom_id = helpers.dom_id(@post)
 
     if @post.destroy
       PurgeCloudflareUrlsJob.perform_later(urls)
-      respond_modal(flash_message: { alert: "記録を削除しました" })
+      respond_modal(flash_message: { notice: "記録を削除しました" })
     else
       respond_modal("shared/flash_and_error", locals: { object: @post }, flash_message: { alert: "記録の削除に失敗しました" })
     end
@@ -122,6 +133,6 @@ class PostsController < ApplicationController
   end
 
   def set_trip
-    @trip = current_user.trips.find_by(public_uid: params[:id])
+    @trip = current_user.trips.find_by(public_uid: params[:trip_id])
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -58,6 +58,12 @@ module ApplicationHelper
       end
     end
 
+    if controller_name == "posts"
+      if action_name.in?(%w[ index ])
+        return true
+      end
+    end
+
     false
   end
 
@@ -97,6 +103,12 @@ module ApplicationHelper
 
     if controller_name == "account_settings"
       if action_name.in?(%w[ show ])
+        return true
+      end
+    end
+
+    if controller_name == "posts"
+      if action_name.in?(%w[ index ])
         return true
       end
     end

--- a/app/javascript/controllers/clickable_card_controller.js
+++ b/app/javascript/controllers/clickable_card_controller.js
@@ -1,0 +1,17 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="clickable-card"
+export default class extends Controller {
+  static targets = ["link"]
+
+  connect() {
+  }
+
+  open(event) {
+    if (event.target.closest("a, button, input, textarea, select, label, summary, [data-clickable-card-ignore]")) {
+      return
+    }
+
+    this.linkTarget.click()
+  }
+}

--- a/app/javascript/controllers/image_loader_controller.js
+++ b/app/javascript/controllers/image_loader_controller.js
@@ -11,6 +11,11 @@ export default class extends Controller {
   connect() {
     this.originalSrc = this.imageTarget.getAttribute("src") || null // 画像へのリダイレクトリンクを取得
     this.retryCount = 0;
+
+    // すでに読み込み済みなら、loadイベントを待たずに表示する
+    if (this.imageTarget.complete && this.imageTarget.naturalWidth > 0) {
+      this.loaded()
+    }
   }
 
   // 画像ロード完了後

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -13,6 +13,9 @@ application.register("base-map", BaseMapController)
 import BottomSheetController from "./bottom_sheet_controller"
 application.register("bottom-sheet", BottomSheetController)
 
+import ClickableCardController from "./clickable_card_controller"
+application.register("clickable-card", ClickableCardController)
+
 import CookieConsentController from "./cookie_consent_controller"
 application.register("cookie-consent", CookieConsentController)
 
@@ -57,6 +60,9 @@ application.register("modal", ModalController)
 
 import PostsController from "./posts_controller"
 application.register("posts", PostsController)
+
+import ScrollResetController from "./scroll_reset_controller"
+application.register("scroll-reset", ScrollResetController)
 
 import ShareButtonController from "./share_button_controller"
 application.register("share-button", ShareButtonController)

--- a/app/javascript/controllers/scroll_reset_controller.js
+++ b/app/javascript/controllers/scroll_reset_controller.js
@@ -1,0 +1,14 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="scroll-reset"
+export default class extends Controller {
+  connect() {
+  }
+
+  top() {
+    this.element.scrollTo({
+      top: 0,
+      behavior: "auto"
+    })
+  }
+}

--- a/app/javascript/controllers/ui_controller.js
+++ b/app/javascript/controllers/ui_controller.js
@@ -350,6 +350,8 @@ export default class extends Controller {
   removeMarker(event){
     const postUuid = event.currentTarget.dataset.postUuid;
 
+    console.log(event.currentTarget)
+
     if(this.hasMapOutlet){
       this.mapOutlet.removeMarker(postUuid);
     }

--- a/app/services/trips/build_default_title_from_start_place_service.rb
+++ b/app/services/trips/build_default_title_from_start_place_service.rb
@@ -18,12 +18,20 @@ class Trips::BuildDefaultTitleFromStartPlaceService
 
     return DEFAULT_TITLE unless response.success?
 
-    location_data = JSON.parse(response.body).dig("response", "location")&.first
-    return DEFAULT_TITLE if location_data.nil?
+    locations = Array(JSON.parse(response.body).dig("response", "location"))
+    return DEFAULT_TITLE if locations.blank?
 
-    prefecture = location_data["prefecture"]
-    city       = location_data["city"]
-    town       = location_data["town"]
+    nearest =
+      if locations.all? { |location| location.key?("distance") }
+        locations.min_by { |location| location["distance"].to_f }
+      else
+        locations.first
+      end
+    return DEFAULT_TITLE if nearest.blank?
+
+    prefecture = nearest["prefecture"]
+    city       = nearest["city"]
+    town       = nearest["town"]
 
     title = [ prefecture, city, town ].compact_blank.join
     return DEFAULT_TITLE if title.blank?

--- a/app/views/bottom_sheets/_show_post_bottom_sheet.html.erb
+++ b/app/views/bottom_sheets/_show_post_bottom_sheet.html.erb
@@ -24,7 +24,7 @@
       <%# 現在地に記録するボタン %>
       <% if @trip && @trip.user_id == current_user&.id %>
         <% unless request.referer&.include?("/trips/") %>
-          <%= button_to new_post_path(@trip),
+          <%= button_to new_trip_post_path(@trip),
                 method: :get,
                 params: { format: :turbo_stream, lat: "", lng: "" },
                 form: { class: "contents" },
@@ -54,7 +54,7 @@
 
       <%# 地図上から場所を選ぶボタン %>
       <% if @trip && @trip.user_id == current_user&.id %>
-        <%= button_to select_position_trip_path(@trip),
+        <%= button_to trip_select_position_path(@trip),
               method: :get,
               params: { format: :turbo_stream },
               data: { action: "click->ui#enablePostPositionMode click->bottom-sheet#close" },

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: post, class: "flex flex-col h-full", data: { controller: "images-compress" }) do |f| %>
+<%= form_with(model: [trip, post], class: "flex flex-col h-full", data: { controller: "images-compress" }) do |f| %>
 
   <%# 隠しフィールド（座標用） %>
   <%= f.hidden_field :latitude %>
@@ -81,8 +81,6 @@
               <span class="text-gray-400 text-sm">No Image</span>
             </div>
           <% end %>
-        </div>
-
         </div>
 
       </div>

--- a/app/views/posts/_list.html.erb
+++ b/app/views/posts/_list.html.erb
@@ -1,0 +1,184 @@
+<%# 各データをループ表示 %>
+<% if posts.present? %>
+  <% posts.each do |post| %>
+    <%# --- 投稿全体コンテナ --- %>
+    <%= turbo_frame_tag dom_id(post), class: "block" do %>
+    <div
+      class="border-b border-gray-200 py-4 px-2 last:border-none max-w-2xl mx-auto hover:bg-[#fff5e6] transition-colors duration-200 cursor-pointer"
+      data-controller="clickable-card"
+      data-action="click->clickable-card#open">
+      <%= link_to "", post_path(post), class: "hidden", data: { turbo_stream: true, clickable_card_target: "link" } %>
+
+      <div class="flex gap-3">
+        <%# --- 左カラム: アイコン --- %>
+        <div class="shrink-0">
+          <% if post.user.avatar.attached? %>
+            <%= image_tag avatar_url(post.user), class: "w-10 h-10 object-cover rounded-full shadow-sm" %>
+          <% else %>
+            <div class="w-10 h-10 bg-orange-400 rounded-full flex items-center justify-center shadow-sm">
+              <%= lucide_icon('user-round', class: "w-6 h-6 text-white") %>
+            </div>
+          <% end %>
+        </div>
+
+        <%# --- 右カラム: メインコンテンツ --- %>
+        <div class="flex-1 min-w-0">
+
+          <%# --- ヘッダー (ユーザー名, 日時, 三点リーダ) --- %>
+          <div class="flex items-start justify-between">
+
+            <%# 名前と日付を横並びに %>
+            <div class="flex items-baseline gap-1.5 truncate pr-2 mt-0.5">
+              <span class="font-bold text-[13px] text-gray-900 truncate">
+                <%= post.user.nickname %>
+              </span>
+            </div>
+
+            <div class="flex gap-3">
+              <span class="text-xs text-gray-500 whitespace-nowrap">
+                <%= post.visited_at&.strftime("%Y/%m/%d %H:%M") %>
+              </span>
+              <%# 三点リーダボタン %>
+              <div class="relative shrink-0 -mt-1 -mr-2" data-controller="dropdown" data-dropdown-post-url-value="<%= confirm_destroy_post_path(post) %>">
+                <button type="button"
+                        class="h-8 w-8 flex items-center justify-center text-gray-400 hover:text-blue-500 hover:bg-blue-50 rounded-full transition"
+                        data-action="click->dropdown#toggle">
+                  <%= lucide_icon('ellipsis', class: "w-5 h-5") %>
+                </button>
+              </div>
+            </div>
+          </div>
+
+          <%# --- 本文 --- %>
+          <% if post.body.present? %>
+            <div class="mt-1 text-[15px] leading-snug text-gray-900 whitespace-pre-line break-words line-clamp-6"><%= post.body %></div>
+          <% end %>
+
+          <%# --- 画像 --- %>
+          <% if post.images.attached? %>
+            <% image_count = post.images.size %>
+
+            <%# 外枠 %>
+            <div class="mt-3 w-full overflow-hidden rounded-xl">
+
+              <% if image_count == 1 %>
+                <% image = post.images.first %>
+                <%# 1枚画像 %>
+                <div class="relative w-full h-[260px] max-h-[260px] bg-gray-100 overflow-hidden" data-controller="image-loader">
+                  <div class="absolute inset-0 flex items-center justify-center transition-opacity" data-image-loader-target="placeholder">
+                    <div class="w-10 h-10 border-2 border-gray-200 border-t-gray-500 rounded-full animate-spin"></div>
+                  </div>
+                  <%= link_to image_viewer_post_path(post, index: 0), data: { turbo_stream: true }, class: "block w-full h-full" do %>
+                    <%= image_tag media_image_url(image.variant(:thumb).key),
+                        loading: "lazy",
+                        class: "w-full h-full object-cover opacity-0",
+                        data: { image_loader_target: "image",
+                                action: "load->image-loader#loaded error->image-loader#error" } %>
+                  <% end %>
+                </div>
+
+              <% elsif image_count == 2 %>
+                <%# 2枚画像：2列 %>
+                <div class="grid grid-cols-2 gap-0.5">
+                  <% post.images.each_with_index do |image, index| %>
+                    <div class="relative aspect-square bg-gray-100 overflow-hidden" data-controller="image-loader">
+                      <div class="absolute inset-0 flex items-center justify-center transition-opacity" data-image-loader-target="placeholder">
+                        <div class="w-10 h-10 border-2 border-gray-200 border-t-gray-500 rounded-full animate-spin"></div>
+                      </div>
+                      <%= link_to image_viewer_post_path(post, index: index),
+                          class: "block w-full h-full",
+                          data: { turbo_stream: true } do %>
+                        <%= image_tag media_image_url(image.variant(:thumb).key),
+                            loading: "lazy",
+                            class: "w-full h-full object-cover opacity-0",
+                            data: { image_loader_target: "image",
+                                    action: "load->image-loader#loaded error->image-loader#error" } %>
+                      <% end %>
+                    </div>
+                  <% end %>
+                </div>
+
+              <% elsif image_count == 3 %>
+                <%# 3枚画像 %>
+                <div class="grid grid-cols-2 gap-0.5 h-[260px] max-h-[260px] overflow-hidden">
+                  <% first_image = post.images.first %>
+
+                  <div class="relative bg-gray-100 overflow-hidden" data-controller="image-loader">
+                    <div class="absolute inset-0 flex items-center justify-center transition-opacity" data-image-loader-target="placeholder">
+                      <div class="w-10 h-10 border-2 border-gray-200 border-t-gray-500 rounded-full animate-spin"></div>
+                    </div>
+                    <%= link_to image_viewer_post_path(post, index: 0), data: { turbo_stream: true }, class: "block w-full h-full" do %>
+                      <%= image_tag media_image_url(first_image.variant(:thumb).key),
+                          loading: "lazy",
+                          class: "w-full h-full object-cover opacity-0",
+                          data: { image_loader_target: "image",
+                                  action: "load->image-loader#loaded error->image-loader#error" } %>
+                    <% end %>
+                  </div>
+
+                  <div class="grid grid-rows-2 gap-0.5 min-h-0">
+                    <% post.images.drop(1).each_with_index do |image, index| %>
+                      <div class="relative bg-gray-100 overflow-hidden min-h-0" data-controller="image-loader">
+                        <div class="absolute inset-0 flex items-center justify-center transition-opacity" data-image-loader-target="placeholder">
+                          <div class="w-10 h-10 border-2 border-gray-200 border-t-gray-500 rounded-full animate-spin"></div>
+                        </div>
+                        <%= link_to image_viewer_post_path(post, index: index + 1), data: { turbo_stream: true }, class: "block w-full h-full" do %>
+                          <%= image_tag media_image_url(image.variant(:thumb).key),
+                              loading: "lazy",
+                              class: "w-full h-full object-cover opacity-0",
+                              data: { image_loader_target: "image",
+                                      action: "load->image-loader#loaded error->image-loader#error" } %>
+                        <% end %>
+                      </div>
+                    <% end %>
+                  </div>
+                </div>
+
+              <% else %>
+                <%# 4枚以上 %>
+                <div class="grid grid-cols-2 gap-0.5 md:grid-cols-3">
+                  <% post.images.first(6).each_with_index do |image, index| %>
+                    <div class="relative aspect-square bg-gray-100 overflow-hidden" data-controller="image-loader">
+                      <div class="absolute inset-0 flex items-center justify-center transition-opacity" data-image-loader-target="placeholder">
+                        <div class="w-10 h-10 border-2 border-gray-200 border-t-gray-500 rounded-full animate-spin"></div>
+                      </div>
+                      <%= link_to image_viewer_post_path(post, index: index), data: { turbo_stream: true }, class: "block w-full h-full" do %>
+                        <%= image_tag media_image_url(image.variant(:thumb).key),
+                            loading: "lazy",
+                            class: "w-full h-full object-cover opacity-0",
+                            data: { image_loader_target: "image",
+                                    action: "load->image-loader#loaded error->image-loader#error" } %>
+                      <% end %>
+                      <% if index == 5 && image_count > 6 %>
+                        <div class="pointer-events-none absolute inset-0 bg-black/50 flex items-center justify-center">
+                          <span class="text-white text-xl font-bold">+<%= image_count - 6 %></span>
+                        </div>
+                      <% end %>
+                    </div>
+                  <% end %>
+                </div>
+              <% end %>
+
+            </div>
+          <% end %>
+
+          <%# --- 地図タイトル--- %>
+          <% if post.trip&.title.present? %>
+            <div class="mt-3 flex items-center gap-1.5 text-[13px] text-gray-400">
+              <%= lucide_icon('map-pin', class: "w-3.5 h-3.5") %>
+              <span><%= link_to post.trip.title, trip_path(post.trip), data: { turbo_frame: "_top" } %></span>
+            </div>
+          <% end %>
+
+        </div>
+      </div>
+    </div>
+    <% end %>
+  <% end %>
+<% else %>
+  <%# 空状態 %>
+  <div class="flex flex-col items-center justify-center py-12 text-gray-500 border-b border-gray-200 max-w-2xl mx-auto">
+    <%= lucide_icon('image-off', class: "w-10 h-10 mb-3 text-gray-300") %>
+    <p class="text-sm">記録が存在しません。</p>
+  </div>
+<% end %>

--- a/app/views/posts/_new.html.erb
+++ b/app/views/posts/_new.html.erb
@@ -6,7 +6,7 @@
   <div class="bg-[#FFFBE6] z-40 w-full h-full md:h-auto md:max-h-[90vh] md:w-full md:max-w-lg md:rounded-2xl shadow-2xl overflow-hidden flex flex-col">
 
     <%# フォームの中身を呼ぶ %>
-    <%= render "form", post: @post %>
+    <%= render "form", post: @post, trip: @trip %>
 
   </div>
 </div>

--- a/app/views/posts/_select_position.html.erb
+++ b/app/views/posts/_select_position.html.erb
@@ -26,7 +26,7 @@
 
   <%# --- 下部の決定ボタン --- %>
   <div class="w-full flex justify-center pb-10">
-    <%= link_to new_post_path(@trip),
+    <%= link_to new_trip_post_path(@trip),
           class: "flex items-center pointer-events-auto justify-center w-16 h-16 bg-orange-500 rounded-full shadow-lg text-white hover:bg-orange-600 active:scale-95 transition-all duration-200",
           data: { posts_target: "postButton", turbo_stream: true } do %>
       <%= lucide_icon('check', class: "w-8 h-8 stroke-[3]") %>

--- a/app/views/posts/destroy.turbo_stream.erb
+++ b/app/views/posts/destroy.turbo_stream.erb
@@ -1,2 +1,3 @@
+<%= turbo_stream.remove(@post_dom_id) %>
 <%= turbo_stream.update "bottom-sheet-container", "" %>
 <%= turbo_stream.update "modal-container", "" %>

--- a/app/views/posts/image_viewer.turbo_stream.erb
+++ b/app/views/posts/image_viewer.turbo_stream.erb
@@ -5,7 +5,7 @@
     <%# --- バックドロップ --- %>
     <div class="modal-backdrop absolute inset-0 bg-black/50 z-0 pointer-events-auto" data-modal-target="modalBackdrop" data-action="click->modal#close"></div>
 
-    <%# モーダル枠 (Swiper本体): 余計なflexクラスを外して w-full h-full に専念させる %>
+    <%# モーダル枠 Swiper本体 %>
     <div data-controller="image-viewer"
           data-image-viewer-initial-slide-value="<%= params[:index].to_i %>"
           class="swiper absolute inset-0 w-full h-full pointer-events-auto z-10 transition-all duration-500 ease-out translate-y-40 opacity-0" data-modal-target="modalBox">

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -14,9 +14,9 @@
   </header>
 
   <%= render "shared/user_records_frame",
-      active_tab: :trips,
-      trips: @trips,
-      geohash_counts: @geohash_counts,
-      posts: nil %>
+      active_tab: :posts,
+      trips: nil,
+      geohash_counts: nil,
+      posts: @posts %>
 
 </div>

--- a/app/views/posts/preview.turbo_stream.erb
+++ b/app/views/posts/preview.turbo_stream.erb
@@ -13,24 +13,28 @@
 
       <%# --- ヘッダー --- %>
       <div class="modal-header shrink-0 z-20 w-full px-2 sm:px-4">
-        <div class="flex items-center justify-between border-b border-orange-200/60 pb-3">
+        <div class="flex items-center justify-between border-b border-orange-200/60 pb-3 gap-2">
 
           <%# 左上コンテナ %>
-          <div class="flex items-center gap-3">
+          <div class="flex items-center gap-3 flex-1 min-w-0">
 
             <%# アイコン %>
-            <% if @post.user.avatar.attached? %>
-              <%= image_tag avatar_url(@post.user), class: "w-10 h-10 object-cover rounded-full shadow-sm" %>
-            <% else %>
-              <div class="w-10 h-10 bg-orange-400 rounded-full flex items-center justify-center shadow-sm">
-                <%= lucide_icon('user-round', class: "w-6 h-6 text-white") %>
-              </div>
-            <% end %>
+            <div class="shrink-0">
+              <% if @post.user.avatar.attached? %>
+                <%= image_tag avatar_url(@post.user), class: "w-10 h-10 object-cover rounded-full shadow-sm" %>
+              <% else %>
+                <div class="w-10 h-10 bg-orange-400 rounded-full flex items-center justify-center shadow-sm">
+                  <%= lucide_icon('user-round', class: "w-6 h-6 text-white") %>
+                </div>
+              <% end %>
+            </div>
 
             <%# ユーザー名と日時 %>
-            <div class="flex flex-col justify-center gap-1">
-              <div class="font-bold text-gray-800 text-base"><%= @post.user.nickname %></div>
-              <div class="text-sm text-gray-500 font-medium">
+            <div class="flex flex-col justify-center gap-1 flex-1 min-w-0">
+              <div class="font-bold text-gray-800 text-base truncate">
+                <%= @post.user.nickname %>
+              </div>
+              <div class="text-sm text-gray-500 font-medium truncate">
                 <%= @post.visited_at&.strftime("%Y/%m/%d %H:%M") %>
               </div>
             </div>
@@ -38,7 +42,7 @@
           </div>
 
           <%# --- 右上コンテナ --- %>
-          <div class="flex items-center gap-3">
+          <div class="flex items-center gap-3 shrink-0">
 
             <%# --- 三点リーダボタン --- %>
             <div class="relative" data-controller="dropdown" data-dropdown-post-url-value="<%= confirm_destroy_post_path(@post) %>">
@@ -97,7 +101,7 @@
               <% else %>
                 <div class="grid grid-cols-2 gap-1 w-full min-h-0  rounded-xl overflow-hidden">
                   <% @post.images.first(4).each_with_index do |image, index| %>
-                    <div class="relative w-full aspect-[4/3] max-h-[18vh]" data-controller="image-loader" style="container-type: inline-size;">
+                    <div class="relative w-full aspect-[4/3] max-h-[15dvh]" data-controller="image-loader" style="container-type: inline-size;">
                       <div class="absolute inset-0 flex items-center justify-center transition-opacity px-1 overflow-hidden" data-image-loader-target="placeholder">
                         <div class="w-10 h-10 border-2 border-gray-200 border-t-gray-500 rounded-full animate-spin"></div>
                       </div>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -178,7 +178,7 @@
               <span class="text-xs">履歴</span>
             <% end %>
 
-            <%= link_to "#", class: tab_class(tutorial_path), data: { turbo_stream: true } do %>
+            <%= link_to "xxx", class: tab_class(tutorial_path), data: { turbo_stream: true } do %>
               <%= lucide_icon('users') %>
               <span class="text-xs">みんなの地図</span>
             <% end %>

--- a/app/views/shared/_user_records_frame.html.erb
+++ b/app/views/shared/_user_records_frame.html.erb
@@ -1,0 +1,55 @@
+<%= turbo_frame_tag "user_records", class: "flex flex-col flex-1 min-h-0 w-full bg-[#FFFBE6]" do %>
+  <%# --- 地図一覧 / 投稿一覧 タブ --- %>
+  <div class="sticky top-0 z-30 bg-white/90 backdrop-blur border-b border-gray-200">
+    <div class="grid grid-cols-2 text-sm font-semibold">
+
+      <%= link_to trips_path,
+          class: [
+            "relative flex items-center justify-center gap-2 py-3 transition",
+            active_tab == :trips ? "text-orange-600" : "text-gray-500 hover:text-gray-900"
+          ],
+          data: {
+            turbo_frame: "user_records",
+            turbo_action: "advance"
+          } do %>
+        <%= lucide_icon("map", class: "w-4 h-4") %>
+        <span>地図一覧</span>
+
+        <% if active_tab == :trips %>
+          <span class="absolute bottom-0 left-1/2 -translate-x-1/2 h-0.5 w-16 rounded-full bg-orange-500"></span>
+        <% end %>
+      <% end %>
+
+      <%= link_to posts_path,
+          class: [
+            "relative flex items-center justify-center gap-2 py-3 transition",
+            active_tab == :posts ? "text-orange-600" : "text-gray-500 hover:text-gray-900"
+          ],
+          data: {
+            turbo_frame: "user_records",
+            turbo_action: "advance"
+          } do %>
+        <%= lucide_icon("image", class: "w-4 h-4") %>
+        <span>記録一覧</span>
+
+        <% if active_tab == :posts %>
+          <span class="absolute bottom-0 left-1/2 -translate-x-1/2 h-0.5 w-16 rounded-full bg-orange-500"></span>
+        <% end %>
+      <% end %>
+
+    </div>
+  </div>
+
+  <%# --- メインリスト部分 --- %>
+  <div
+    class="flex-1 min-h-0 overflow-y-auto overflow-x-hidden pb-28 block w-full"
+    data-controller="scroll-reset"
+    data-action="turbo:frame-load->scroll-reset#top">
+
+    <% if active_tab == :trips %>
+      <%= render "trips/list", trips: trips, geohash_counts: geohash_counts %>
+    <% elsif active_tab == :posts %>
+      <%= render "posts/list", posts: posts %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/trips/_list.html.erb
+++ b/app/views/trips/_list.html.erb
@@ -1,0 +1,46 @@
+<%# 各データをループ表示 %>
+<% if trips.present? %>
+  <% trips.each do |trip| %>
+    <% geohash_count = geohash_counts[trip.id] || 0 %>
+
+    <div class="flex flex-col items-center border-b border-gray-300 py-8 last:border-none">
+
+      <%# タイトル %>
+      <div class="mb-2 text-lg font-bold text-black">
+        <%= trip.title %>
+      </div>
+
+      <%# 開始日時 %>
+      <div class="mb-5 text-sm text-gray-800">
+        <%= trip.started_at.strftime("%Y/%m/%d %H:%M") %>
+      </div>
+
+      <%# 地図画像コンテナ %>
+      <%= link_to trip_path(trip) do %>
+        <div class="mb-4 h-64 w-64 overflow-hidden rounded-2xl border border-gray-400 bg-white shadow-sm">
+          <%# <%= image_tag trip.image_url, class: "h-full w-full object-cover" %>
+          <div class="flex h-full w-full items-center justify-center bg-gray-50 text-gray-400">
+            Map Image
+          </div>
+        </div>
+      <% end %>
+
+      <%# 詳細データ %>
+      <div class="flex flex-col items-center gap-1 text-sm font-medium text-black">
+        <div>
+          距離: <%= trip.total_distance %> m / <%= geohash_count %> マス
+        </div>
+        <div>
+          探索時間: <%= format_duration(trip.activity_time) %>
+        </div>
+      </div>
+
+    </div>
+  <% end %>
+<% else %>
+  <%# 空状態 %>
+  <div class="flex flex-col items-center justify-center py-12 text-gray-500 border-b border-gray-200 max-w-2xl mx-auto">
+    <%= lucide_icon('image-off', class: "w-10 h-10 mb-3 text-gray-300") %>
+    <p class="text-sm">地図が存在しません。</p>
+  </div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,15 +48,12 @@ Rails.application.routes.draw do
       get :edit_status
       get :edit_title
       patch :update_title
-      get "select_position", to: "posts#select_position"
-      resources :posts, only: %i[ new create ] do
-        collection do
-        end
-      end
     end
+    get "select_position", to: "posts#select_position"
+    resources :posts, only: %i[ new create ]
   end
 
-  resources :posts, only: %i[ show destroy ] do
+  resources :posts, only: %i[ index show destroy ] do
     member do
       get :preview
       get :image_viewer

--- a/workers/post-images-worker/src/index.js
+++ b/workers/post-images-worker/src/index.js
@@ -14,9 +14,6 @@ export default {
 		const url = new URL(request.url);
 		const match = url.pathname.match(/^\/(?:variants\/)?posts\/(\d+)\/(.+)$/);
 
-		console.log(url)
-		console.log(match)
-
 		if (!match) {
 			return new Response("Not Found", { status: 404 });
 		}
@@ -79,6 +76,8 @@ export default {
 		} else {
 			res.headers.set("Cache-Control", "no-store");
 		}
+
+		console.log(res)
 
 		return res;
 	}


### PR DESCRIPTION
## issue
- close: #179 

## 実装内容
- posts#indexでユーザーの投稿一覧を取得
- posts/index.html.erbでユーザーの投稿一覧を表示
- 投稿一覧を地図一覧と同じページで表示するために、user_records_frame.html.erbを作成
- trips/indexとposts/indexをどちらも同じ画面内で、turbo frame tagで中身を差し替えて表示するよう実装
- 一覧から投稿を削除したときに、削除した投稿が消えるように実装

## issueとの差分
- 投稿一覧と地図一覧を今までの記録一覧として同じページで表示するように変更

## 動作確認方法
- ブラウザで正しくデータが表示されているか確認

## 補足
- 地図一覧ページはまだ未完成状態
