### PR TITLE
新しい霧晴れ機能追加

### DIFF
--- a/app/controllers/bottom_sheets_controller.rb
+++ b/app/controllers/bottom_sheets_controller.rb
@@ -6,6 +6,12 @@ class BottomSheetsController < ApplicationController
 
   def show_post_bottom_sheet
     @trip = current_user.trips.find_by(public_uid: params[:id])
+
+    unless @trip
+      respond_modal("shared/flash_message", flash_message: { alert: "この地図は見つかりません" })
+      return
+    end
+
     respond_modal
   end
 end

--- a/app/javascript/controllers/base_map_controller.js
+++ b/app/javascript/controllers/base_map_controller.js
@@ -9,6 +9,7 @@ import { Protocol } from "pmtiles";
 // 定数定義
 const INITIAL_ZOOM_LEVEL = 17;    // 初期のズームレベル
 const DEBUG_MODE = false;
+const USE_WEBGL_FOG = true;
 
 // Connects to data-controller="base-map"
 export default class extends Controller {
@@ -38,13 +39,13 @@ export default class extends Controller {
     this.cumulativeFeature = null;
 
     // 世界を覆う霧のマスク
-    this.worldFeature = turf.polygon([[
-      [-180, 90],
-      [-180, -90],
-      [180, -90],
-      [180, 90],
-      [-180, 90]
-    ]]);
+    // this.worldFeature = turf.polygon([[
+    //   [-180, 90],
+    //   [-180, -90],
+    //   [180, -90],
+    //   [180, 90],
+    //   [-180, 90]
+    // ]]);
   }
 
   disconnect(_element){
@@ -147,6 +148,8 @@ export default class extends Controller {
     visitedGeohashes.forEach((geohash) => {
       this.addGeohashesAndGetNew(geohash, targetGeohashesSet)
     });
+
+    return;
 
     // geohashから開放するポリゴンの配列を作成
     const polygonsToMerge = [...targetGeohashesSet].map(hash => this.createPolygonFromGeohash(hash));
@@ -341,24 +344,46 @@ export default class extends Controller {
 
   // 霧の初期化
   fogInit(){
-    if (!this.map.getSource('fog')) {
-      this.map.addSource('fog', {
-        type: 'geojson',
-        data: this.worldFeature
-      });
-    }
+    if (USE_WEBGL_FOG){
+      // 文字レイヤー（Symbol）のIDを探す
+      // const layers = this.map.getStyle().layers;
+      // let firstSymbolId = null;
+      // for (const layer of layers) {
+      //   if (layer.type === 'symbol') {
+      //     firstSymbolId = layer.id;
+      //     break;
+      //   }
+      // }
 
-    if (!this.map.getLayer('fog-layer')) {
-      this.map.addLayer({
-        id: 'fog-layer',
-        type: "fill",
-        source: 'fog',
-        paint: {
-          "fill-color": "#ffffff",
-          "fill-opacity": 0.9,
-          'fill-antialias': false,
-        }
+      this.fogCustomLayer = new GeohashFogCustomLayer({
+        id: "geohash-fog-custom-layer",
+        opacity: 0.9,
       });
+
+      if (!this.map.getLayer('geohash-fog-custom-layer')) {
+        this.map.addLayer(this.fogCustomLayer);
+        // this.map.addLayer(this.fogCustomLayer, firstSymbolId);
+      }
+    } else {
+      if (!this.map.getSource('fog')) {
+        this.map.addSource('fog', {
+          type: 'geojson',
+          data: this.worldFeature
+        });
+      }
+
+      if (!this.map.getLayer('fog-layer')) {
+        this.map.addLayer({
+          id: 'fog-layer',
+          type: "fill",
+          source: 'fog',
+          paint: {
+            "fill-color": "#ffffff",
+            "fill-opacity": 0.9,
+            'fill-antialias': false,
+          }
+        });
+      }
     }
   }
 
@@ -372,9 +397,353 @@ export default class extends Controller {
     source.setData(geojsonData);
   }
 
+  updateCustomFogLayer() {
+    if (!this.fogCustomLayer) return
+
+    const visibleHashes = this.getVisibleClearedGeohashes()
+
+    this.fogCustomLayer.setHashes(visibleHashes)
+    this.map.triggerRepaint()
+  }
+
   setFogOpacity(opacity){
-    if(this.map){
-      this.map.setPaintProperty('fog-layer', 'fill-opacity', opacity);
+    // if(this.map){
+    //   this.map.setPaintProperty('fog-layer', 'fill-opacity', opacity);
+    // }
+    if (this.fogCustomLayer) {
+      this.fogCustomLayer.opacity = opacity;
+      this.map.triggerRepaint(); // 再描画
     }
+  }
+
+  // 累計地図セット
+  setCumulativeGeohashesAndFeature(cumulativeGeohashes){
+    if(this.cumulativeModeStatus === "loading" || this.cumulativeModeStatus === "isReady") return;
+    this.cumulativeModeStatus = "loading"
+
+    return fetch("/api/v1/my_map", { signal: this.ac.signal })
+      .then(res => {
+        if(!res.ok) throw new Error(`HTTP ${res.status}`);
+        return res.json();
+      })
+      .then((data) => {
+        if (this.ac.signal.aborted || !this.element.isConnected) return;
+
+        // this.cumulativeFeature = this.generateFeatureFromGeohashes(data.geohashes, cumulativeGeohashes);
+        this.generateFeatureFromGeohashes(data.geohashes, cumulativeGeohashes);
+
+        // console.log(this.cumulativeFeature)
+
+        this.cumulativeModeStatus = "isReady"
+      })
+      .catch((e) => {
+        this.cumulativeModeStatus = "notReady"
+        this.uiOutlet.disableCumulative();
+        if (e.name == "AbortError") {
+          console.debug("ページ遷移によるエラー", e);
+          return;
+        }
+        console.error(e);
+      });
+  }
+
+  // 解放ずみgeohashを取得
+  getVisibleClearedGeohashes() {
+    if (!this.map) return []
+
+    const merged = new Set()
+
+    if (this.cumulativeMode && this.cumulativeGeohashes) {
+      this.cumulativeGeohashes.forEach(hash => merged.add(hash))
+    }
+
+    if (this.visitedGeohashes) {
+      this.visitedGeohashes.forEach(hash => merged.add(hash))
+    }
+
+    // return this.filterVisibleGeohashes(merged)
+    return Array.from(merged)
+  }
+
+  // 現在の描画範囲内のgeohashを返す
+  filterVisibleGeohashes(geohashes) {
+    const bounds = this.map.getBounds() // 現在の表示範囲を取得
+
+    const west = bounds.getWest()
+    const east = bounds.getEast()
+    const south = bounds.getSouth()
+    const north = bounds.getNorth()
+
+    return Array.from(geohashes).filter(hash => {
+      const bbox = ngeohash.decode_bbox(hash)
+
+      const minLat = bbox[0]
+      const minLng = bbox[1]
+      const maxLat = bbox[2]
+      const maxLng = bbox[3]
+
+      return !(
+        maxLng < west ||
+        minLng > east ||
+        maxLat < south ||
+        minLat > north
+      )
+    })
+  }
+
+  setFogColor(r, g, b) {
+    if (this.fogCustomLayer) {
+      this.fogCustomLayer.color = [r / 255, g / 255, b / 255];
+      this.map.triggerRepaint();
+    }
+  }
+}
+
+
+class GeohashFogCustomLayer {
+  constructor({ id = "geohash-fog-custom-layer", opacity = 0.65, color = [1.0, 1.0, 1.0] } = {}) {
+    this.id = id;
+    this.type = "custom";
+    this.renderingMode = "2d";
+
+    this.visible = true;
+    this.opacity = opacity;
+    this.color = color;
+    this.hashes = [];
+    this.vertexData = new Float32Array([]);
+
+    // アンカー座標（メルカトル座標系）
+    this.anchor = { x: 0, y: 0 };
+
+    // WebGLリソース
+    this.gl = null;
+    this.cellProgram = null;
+    this.fogProgram = null;
+    this.cellBuffer = null;
+    this.fullscreenBuffer = null;
+  }
+
+  // 表示するGeohashを更新し、頂点バッファを再構築する
+  setHashes(hashes) {
+    this.hashes = hashes || [];
+
+    // アンカーの設定
+    // 描画対象がある場合、最初のGeohashの中心付近を基準点にする。高ズーム時でも頂点座標の有効桁数が保たれる
+    if (this.hashes.length > 0) {
+      const firstBbox = ngeohash.decode_bbox(this.hashes[0]);
+      const center = maplibregl.MercatorCoordinate.fromLngLat({
+        lng: (firstBbox[1] + firstBbox[3]) / 2,
+        lat: (firstBbox[0] + firstBbox[2]) / 2
+      });
+      this.anchor.x = center.x;
+      this.anchor.y = center.y;
+    }
+
+    // 頂点データの構築
+    this.vertexData = this.buildVertexData(this.hashes);
+
+    // GPUバッファの更新
+    if (this.gl && this.cellBuffer) {
+      this.gl.bindBuffer(this.gl.ARRAY_BUFFER, this.cellBuffer);
+      this.gl.bufferData(this.gl.ARRAY_BUFFER, this.vertexData, this.gl.DYNAMIC_DRAW);
+    }
+  }
+
+  // Geohashの配列を三角形ポリゴンの頂点配列に変換。座標は this.anchor からの相対値として計算
+  buildVertexData(hashes) {
+    const vertices = [];
+
+    for (const hash of hashes) {
+      const bbox = ngeohash.decode_bbox(hash);
+
+      // メルカトル座標を取得
+      const p1 = maplibregl.MercatorCoordinate.fromLngLat({ lng: bbox[1], lat: bbox[0] });
+      const p2 = maplibregl.MercatorCoordinate.fromLngLat({ lng: bbox[3], lat: bbox[0] });
+      const p3 = maplibregl.MercatorCoordinate.fromLngLat({ lng: bbox[3], lat: bbox[2] });
+      const p4 = maplibregl.MercatorCoordinate.fromLngLat({ lng: bbox[1], lat: bbox[2] });
+
+      // アンカーからの差分を計算
+      const x1 = p1.x - this.anchor.x, y1 = p1.y - this.anchor.y;
+      const x2 = p2.x - this.anchor.x, y2 = p2.y - this.anchor.y;
+      const x3 = p3.x - this.anchor.x, y3 = p3.y - this.anchor.y;
+      const x4 = p4.x - this.anchor.x, y4 = p4.y - this.anchor.y;
+
+      // 1つのGeohash(四角形)を2つの三角形に分割
+      vertices.push(
+        x1, y1,
+        x2, y2,
+        x3, y3,
+
+        x1, y1,
+        x3, y3,
+        x4, y4,
+      );
+    }
+
+    return new Float32Array(vertices);
+  }
+
+  // レイヤーがマップに追加された時の初期化処理
+  onAdd(map, gl) {
+    this.map = map;
+    this.gl = gl;
+
+    // セル描画用プログラム（stencil用）
+    this.cellProgram = this.createProgram(
+      gl,
+      `
+        precision highp float;
+        attribute vec2 a_pos;
+        uniform mat4 u_matrix;
+        void main() {
+          gl_Position = u_matrix * vec4(a_pos, 0.0, 1.0);
+        }
+      `,
+      `
+        precision highp float;
+        void main() {
+          gl_FragColor = vec4(1.0, 0.0, 0.0, 1.0);
+        }
+      `
+    );
+
+    // 画面全体を覆う霧用プログラム
+    this.fogProgram = this.createProgram(
+      gl,
+      `
+        precision highp float;
+        attribute vec2 a_pos;
+        void main() {
+          gl_Position = vec4(a_pos, 0.0, 1.0);
+        }
+      `,
+      `
+        precision highp float;
+        uniform float u_opacity;
+        uniform vec3 u_color;
+
+        void main() {
+          gl_FragColor = vec4(u_color * u_opacity, u_opacity);
+        }
+      `
+    );
+
+    this.cellBuffer = gl.createBuffer();
+
+    // フルスクリーン描画用の四角形バッファ
+    this.fullscreenBuffer = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, this.fullscreenBuffer);
+    gl.bufferData(
+      gl.ARRAY_BUFFER,
+      new Float32Array([
+        -1, -1,  1, -1,  1,  1,
+        -1, -1,  1,  1, -1,  1,
+      ]),
+      gl.STATIC_DRAW
+    );
+  }
+
+  // 毎フレームの描画処理
+  render(gl, args) {
+    if (!this.cellProgram || !this.fogProgram || !this.visible) return;
+
+    // MapLibreの行列(4x4)をコピーして修正を加える
+    const matrix = [...args.defaultProjectionData.mainMatrix];
+
+    // 行列に対して、アンカー分の移動を適用。相対座標で計算された頂点が正しい位置にレンダリングされる
+    this.translateMatrix(matrix, this.anchor.x, this.anchor.y);
+
+
+    // ステンシルマスクを「書き込み許可」にする.gl.clear(gl.STENCIL_BUFFER_BIT) が効かない場合があるから
+    gl.stencilMask(0xff);
+
+    // 深度テストとブレンドの設定
+    gl.disable(gl.DEPTH_TEST); // 霧が地図の下に隠れないようにする
+    gl.enable(gl.BLEND);
+    gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
+
+    // ステンシルバッファを完全にクリア
+    gl.enable(gl.STENCIL_TEST);
+    gl.clearStencil(0);
+    gl.clear(gl.STENCIL_BUFFER_BIT);
+
+    // 晴れている場所をステンシルに記録
+    gl.colorMask(false, false, false, false);
+    gl.stencilFunc(gl.ALWAYS, 1, 0xff);
+    gl.stencilOp(gl.KEEP, gl.KEEP, gl.REPLACE);
+
+    gl.useProgram(this.cellProgram);
+    const matrixLocation = gl.getUniformLocation(this.cellProgram, "u_matrix");
+    gl.uniformMatrix4fv(matrixLocation, false, matrix);
+
+    gl.bindBuffer(gl.ARRAY_BUFFER, this.cellBuffer);
+    const cellPosLocation = gl.getAttribLocation(this.cellProgram, "a_pos");
+    gl.enableVertexAttribArray(cellPosLocation);
+    gl.vertexAttribPointer(cellPosLocation, 2, gl.FLOAT, false, 0, 0);
+
+    const cellVertexCount = this.vertexData.length / 2;
+    if (cellVertexCount > 0) {
+      gl.drawArrays(gl.TRIANGLES, 0, cellVertexCount);
+    }
+
+    // ステンシルが1以外の場所に霧を塗る
+    gl.colorMask(true, true, true, true);
+    gl.stencilFunc(gl.NOTEQUAL, 1, 0xff);
+    gl.stencilOp(gl.KEEP, gl.KEEP, gl.KEEP);
+
+    gl.useProgram(this.fogProgram);
+
+    const opacityLocation = gl.getUniformLocation(this.fogProgram, "u_opacity");
+    gl.uniform1f(opacityLocation, this.opacity);
+
+    const colorLocation = gl.getUniformLocation(this.fogProgram, "u_color")
+    gl.uniform3f(colorLocation, this.color[0], this.color[1], this.color[2])
+
+    gl.bindBuffer(gl.ARRAY_BUFFER, this.fullscreenBuffer);
+    const fogPosLocation = gl.getAttribLocation(this.fogProgram, "a_pos");
+    gl.enableVertexAttribArray(fogPosLocation);
+    gl.vertexAttribPointer(fogPosLocation, 2, gl.FLOAT, false, 0, 0);
+
+    gl.drawArrays(gl.TRIANGLES, 0, 6);
+
+    // 後片付けMapLibreの次のレイヤー描画に影響を与えないため
+    gl.disable(gl.STENCIL_TEST);
+    gl.stencilMask(0x00); // ステンシル書き込みを禁止に戻す
+  }
+
+  // 4x4 行列（列優先配列）に平行移動を適用するヘルパー
+  translateMatrix(m, tx, ty) {
+    // 列優先(column-major)行列の移動成分(m12, m13, m14, m15)を更新
+    m[12] = m[0] * tx + m[4] * ty + m[12];
+    m[13] = m[1] * tx + m[5] * ty + m[13];
+    m[14] = m[2] * tx + m[6] * ty + m[14];
+    m[15] = m[3] * tx + m[7] * ty + m[15];
+  }
+
+  createShader(gl, type, source) {
+    const shader = gl.createShader(type);
+    gl.shaderSource(shader, source);
+    gl.compileShader(shader);
+    if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+      const error = gl.getShaderInfoLog(shader);
+      gl.deleteShader(shader);
+      throw new Error(error);
+    }
+    return shader;
+  }
+
+  createProgram(gl, vertexSource, fragmentSource) {
+    const vertexShader = this.createShader(gl, gl.VERTEX_SHADER, vertexSource);
+    const fragmentShader = this.createShader(gl, gl.FRAGMENT_SHADER, fragmentSource);
+    const program = gl.createProgram();
+    gl.attachShader(program, vertexShader);
+    gl.attachShader(program, fragmentShader);
+    gl.linkProgram(program);
+    if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+      const error = gl.getProgramInfoLog(program);
+      gl.deleteProgram(program);
+      throw new Error(error);
+    }
+    return program;
   }
 }

--- a/app/javascript/controllers/history_map_controller.js
+++ b/app/javascript/controllers/history_map_controller.js
@@ -2,6 +2,9 @@ import BaseMapController from "./base_map_controller.js"
 import maplibregl from 'maplibre-gl'
 import 'maplibre-gl/dist/maplibre-gl.css'
 import * as turf from "@turf/turf"
+import ngeohash from 'ngeohash'
+
+const USE_WEBGL_FOG = true;
 
 // Connects to data-controller="history-map"
 export default class extends BaseMapController {
@@ -13,7 +16,8 @@ export default class extends BaseMapController {
     // base mapのconnectを実行
     super.connect();
 
-    this.cumulativeFeature = this.generateFeatureFromGeohashes(this.visitedGeohashesValue, this.cumulativeGeohashes);
+    await this.initVisitedGeohashes();
+    // this.cumulativeFeature = this.generateFeatureFromGeohashes(this.visitedGeohashesValue, this.cumulativeGeohashes);
 
     // 中央位置設定
     if(this.longitudeValue && this.latitudeValue){
@@ -26,6 +30,8 @@ export default class extends BaseMapController {
     await this.initializeMap(this.center)
 
     if (!this.map) return;
+
+    this.fitToVisitedArea();
 
     // アトリビューション表記
     this.map.addControl(new maplibregl.AttributionControl({ compact: true }), "bottom-right");
@@ -48,24 +54,38 @@ export default class extends BaseMapController {
     // 地図の読み込みが終わった後に実行
     this.map.on('load', () => {
       // 霧を初期化
-      this.fogInit()
+      this.fogInit();
+      this.setFogOpacity(0.6);
+      this.setFogColor(26, 38, 52)
+      this.setupCustomFogLayerEvents()
 
-      toHide.forEach(id => {
-        if (this.map.getLayer(id)) {
-          this.map.setLayoutProperty(id, "visibility", "none");
-        }
-      });
+      // toHide.forEach(id => {
+      //   if (this.map.getLayer(id)) {
+      //     this.map.setLayoutProperty(id, "visibility", "none");
+      //   }
+      // });
 
-      this.executeFogClearing();
+      // this.executeFogClearing();
+      this.updateCustomFogLayer();
 
-      this.initRevealedAreaLayer();
-      this.updateRevealedArea();
+      // this.initRevealedAreaLayer();
+      // this.updateRevealedArea();
 
       this.addMarkers();
 
       this.mapInitEnd = true;
       this.maybeClearOverlay();
     })
+  }
+
+  async initVisitedGeohashes(){
+    this.visitedGeohashes = new Set();
+    console.log(window.location.pathname.slice(1))
+    if (String(window.location.pathname.slice(1)) === "my_map"){
+      await this.setCumulativeGeohashesAndFeature(this.visitedGeohashes);
+    } else {
+      this.generateFeatureFromGeohashes(this.visitedGeohashesValue, this.visitedGeohashes);
+    }
   }
 
   executeFogClearing(){
@@ -121,28 +141,40 @@ export default class extends BaseMapController {
     this.maybeClearOverlay();
   }
 
-  // 霧の初期化のhistorymapバージョン
-  fogInit(){
-    if (!this.map.getSource('fog')) {
-      this.map.addSource('fog', {
-        type: 'geojson',
-        data: this.worldFeature
-      });
-    }
+  // 霧の初期化
+  // fogInit(){
+  //   if (USE_WEBGL_FOG){
+  //     this.fogCustomLayer = new GeohashFogCustomLayer({
+  //       id: "geohash-fog-custom-layer",
+  //       opacity: 0.65,
+  //     })
 
-    if (!this.map.getLayer('fog-layer')) {
-      this.map.addLayer({
-        id: 'fog-layer',
-        type: "fill",
-        source: 'fog',
-        paint: {
-          "fill-color": "#f2eee8",
-          "fill-opacity": 0.55,
-          'fill-antialias': false,
-        }
-      });
-    }
-  }
+  //     if (!this.map.getLayer('geohash-fog-custom-layer')) {
+  //       this.map.addLayer(this.fogCustomLayer)
+  //     }
+
+  //   } else {
+  //     if (!this.map.getSource('fog')) {
+  //       this.map.addSource('fog', {
+  //         type: 'geojson',
+  //         data: this.worldFeature
+  //       });
+  //     }
+
+  //     if (!this.map.getLayer('fog-layer')) {
+  //       this.map.addLayer({
+  //         id: 'fog-layer',
+  //         type: "fill",
+  //         source: 'fog',
+  //         paint: {
+  //           "fill-color": "#f2eee8",
+  //           "fill-opacity": 0.55,
+  //           'fill-antialias': false,
+  //         }
+  //       });
+  //     }
+  //   }
+  // }
 
   initRevealedAreaLayer() {
     if (!this.map.getSource('revealed-area')) {
@@ -197,5 +229,48 @@ export default class extends BaseMapController {
     if (!source) return;
 
     source.setData(this.cumulativeFeature || turf.featureCollection([]));
+  }
+
+  setupCustomFogLayerEvents() {
+    // moveendとzoomendの両方で実行
+    const updateEvents = ["moveend", "zoomend"];
+
+    updateEvents.forEach(eventType => {
+      this.map.on(eventType, () => {
+        // カスタムレイヤーが存在し、かつ表示中であれば更新する
+        if (this.fogCustomLayer && this.visitedGeohashes?.size > 0) {
+          this.updateCustomFogLayer();
+        }
+      });
+    });
+  }
+
+  fitToVisitedArea() {
+    if (!this.visitedGeohashes || this.visitedGeohashes.size === 0) return;
+
+    let minLat = Infinity, minLng = Infinity;
+    let maxLat = -Infinity, maxLng = -Infinity;
+
+    // すべてのGeohashを走査して外郭を探す
+    this.visitedGeohashes.forEach(hash => {
+      const bbox = ngeohash.decode_bbox(hash); // [s, w, n, e]
+
+      if (bbox[0] < minLat) minLat = bbox[0];
+      if (bbox[1] < minLng) minLng = bbox[1];
+      if (bbox[2] > maxLat) maxLat = bbox[2];
+      if (bbox[3] > maxLng) maxLng = bbox[3];
+    });
+
+    // MapLibreのfitBoundsに渡す
+    this.map.fitBounds(
+      [[minLng, minLat], [maxLng, maxLat]],
+      {
+        padding: 50,
+        duration: 0,
+        bearing: 0,
+        pitch: 0,
+        essential: true
+      }
+    );
   }
 }

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -13,10 +13,14 @@ const FORCE_RECORD_MS       = 30000; // 30000ミリ秒 (記録間隔の最大値
 const FLUSH_INTERVAL_MS     = 60000; // 60000ミリ秒 (送信間隔)
 const MAP_OVERLAY_TIMEOUT   = 5000;  // マップオーバーレイを消すまでタイムアウト時間
 const MAP_OVERLAY_DISTANCE  = 100;   // マップオーバーレイを消すまで距離
-const GEOLOCATE_MAXIMUM_AGE = 3000;  // 位置情報のキャッシュ許容時間
+const GEOLOCATE_MAXIMUM_AGE = 86400000;  // 位置情報のキャッシュ許容時間
+const GEOLOCATE_TIMEOUT     = 10000;
 const PERMISSION_DENIED     = 1;     // 位置情報不許可時のerror値
 const INITIAL_ZOOM_LEVEL = 17;
 const DEBUG_MODE = false;
+const DEBUG_BULK_SAVE_CHUNK_SIZE = 500;
+const DEBUG_BULK_SAVE_INTERVAL_MS = 200;
+const USE_WEBGL_FOG = true
 
 // Connects to data-controller="map"
 export default class extends BaseMapController {
@@ -43,7 +47,7 @@ export default class extends BaseMapController {
     this.cumulativeMode = false;
     this.cumulativeModeStatus = "notReady";
     this.forceStopCumulative = false;
-    this.setCumulativeGeohashesAndFeature(this.cumulativeGeohashes);
+    // this.setCumulativeGeohashesAndFeature(this.cumulativeGeohashes);
 
     // 地図の設定
     this.status = STATUS.STOPPED; // 地図のステータスを初期化
@@ -100,7 +104,8 @@ export default class extends BaseMapController {
     this.geolocate = new maplibregl.GeolocateControl({
       positionOptions: {
         enableHighAccuracy: true, // 高精度モードを有効
-        maximumAge: GEOLOCATE_MAXIMUM_AGE // 位置情報のキャッシュ許容時間
+        maximumAge: GEOLOCATE_MAXIMUM_AGE,// 位置情報のキャッシュ許容時間
+        timeout: GEOLOCATE_TIMEOUT
       },
       trackUserLocation: true, // 移動に合わせてドットが動く
       showUserHeading: true, // スマホの向いている方角を表示
@@ -175,7 +180,7 @@ export default class extends BaseMapController {
       const currentZoom = this.map.getZoom(); // 現在のズーム率を取得
 
       // maxとminのズームを現在のズームに固定
-      this.geolocate.options.fitBoundsOptions.maxZoom = currentZoom;
+      // this.geolocate.options.fitBoundsOptions.maxZoom = currentZoom;
       this.geolocate.options.fitBoundsOptions.minZoom = currentZoom;
     });
   }
@@ -213,6 +218,7 @@ export default class extends BaseMapController {
     // 地図の読み込みが終わった後に実行
     this.map.on('load', () => {
       this.fogInit(); // 霧を初期化
+      this.setupCustomFogLayerEvents()
 
       // toHide配列の中身のidの要素を透過
       toHide.forEach(id => {
@@ -221,7 +227,7 @@ export default class extends BaseMapController {
         }
       });
 
-      this.checkLocationPermissions(); // 規約と位置情報をチェックして現在地の表示と霧を晴らす
+      this.checkLocationPermissions(); // 規約と位置情報をチェックして現在地追従オン
 
       // デバッグ用：クリックで霧を晴らす
       if(DEBUG_MODE){
@@ -229,7 +235,16 @@ export default class extends BaseMapController {
           const { lng, lat } = e.lngLat; // クリックした箇所のlng,latを取得
 
           // e.originalEvent.altKey で Alt(Option)キーが押されているか判定
-          if (e.originalEvent.altKey) {
+          if (e.originalEvent.altKey && e.originalEvent.metaKey) {
+            console.log(`[累計地図デバッグ保存] ${lat}, ${lng} 周辺のfootprintsを大量保存します`);
+
+            this.debugSaveMassiveFootprintsForCumulativeMap(lat, lng, {
+              offset: 0.01,
+              precision: 9,
+              step: 20,
+              maxCount: 10000,
+            });
+          } else if (e.originalEvent.altKey) {
             console.log(`[負荷テスト] ${lat}, ${lng} 周辺を一括開放します`);
             this.debugClearMassiveFog(lat, lng);
           } else {
@@ -293,10 +308,6 @@ export default class extends BaseMapController {
   handleGeolocate = (data) => {
     if (!this.map || !this.element.isConnected) return; // ガード
 
-    // センターの設定
-    if(!this.mapInitEnd) {
-      this.map.setCenter([data.coords.longitude, data.coords.latitude])
-    }
     // 各種データの取得
     const lng = data.coords.longitude; // 経度
     const lat = data.coords.latitude;  // 緯度
@@ -317,7 +328,11 @@ export default class extends BaseMapController {
 
     // 霧の更新
     if (this.status !== STATUS.PAUSED) {
-      this.executeFogClearing()
+      if (USE_WEBGL_FOG) {
+        this.updateRealtimeFogClearing()
+      } else {
+        this.executeFogClearing()
+      }
     }
 
     this.mapInitEnd = true;
@@ -331,7 +346,7 @@ export default class extends BaseMapController {
     }
   }
 
-  // 位置情報と規約の状態をチェックして地図の表示と霧を晴らす
+  // 位置情報と規約の状態をチェックして地図表示とオーバーレイを晴らす
   checkLocationPermissions = () => {
 
     this.hasAccepted = this.getCookie("terms_accepted"); // 規約に同意済みか最新のクッキーを取得
@@ -350,12 +365,14 @@ export default class extends BaseMapController {
         } else if (result.state === 'granted'){ // 許可しているとき
 
           if (this.map && this.geolocate) {
-            this.map.jumpTo({
-              center: [this.currentLng, this.currentLat]
-            })
             this.geolocate.trigger(); // 地図上の現在地ボタンを起動
-            this.mapInitEnd = true;   // 地図の設定完了フラグをtrueに
-            this.maybeClearOverlay(); // 霧を晴らす
+
+            setTimeout(() => {
+              if (!this.mapInitEnd) {
+                this.mapInitEnd = true;
+                this.maybeClearOverlay();
+              }
+            }, GEOLOCATE_TIMEOUT);
           }
 
         } else if(result.state === 'prompt') { // 確認のダイアログが表示された時
@@ -369,7 +386,7 @@ export default class extends BaseMapController {
             if (result.state === 'granted') { // 位置情報を許可するとき
               if (this.map && this.geolocate) {
                 this.mapInitEnd = true;   // 地図の設定完了フラグをtrueに
-                this.maybeClearOverlay(); // 霧を晴らす
+                this.maybeClearOverlay(); // オーバーレイ要素を晴らす
               }
             } else if (result.state === 'denied') { // 位置情報を許可しないが押された時
               this.showLocationDeniedModal(); // 位置情報を許可するよう促すモーダルを表示
@@ -610,7 +627,8 @@ export default class extends BaseMapController {
     this.tripId = id;
     if(oldVisitedGeohashes){
       this.visitedGeohashes.clear();
-      this.visitedFeature = this.generateFeatureFromGeohashes(oldVisitedGeohashes, this.visitedGeohashes);
+      // this.visitedFeature = this.generateFeatureFromGeohashes(oldVisitedGeohashes, this.visitedGeohashes);
+      this.generateFeatureFromGeohashes(oldVisitedGeohashes, this.visitedGeohashes);
     }
   }
 
@@ -715,8 +733,12 @@ export default class extends BaseMapController {
   resetFog() {
     this.visitedFeature = null;
     this.visitedGeohashes.clear();
-    console.log(this.visitedGeohashes)
-    this.executeFogClearing(true);
+
+    if (USE_WEBGL_FOG) {
+      this.updateRealtimeFogClearing(true)
+    } else {
+      this.executeFogClearing(true)
+    }
 
     Object.values(this.markers).forEach(marker => {
       marker.remove();
@@ -756,10 +778,10 @@ export default class extends BaseMapController {
 
     let visitedUnion = turf.clone(this.visitedFeature);
 
-    if (this.cumulativeMode && this.cumulativeFeature) {
-      const featureCollection = turf.featureCollection([visitedUnion, this.cumulativeFeature].filter(Boolean));
-      visitedUnion = turf.union(featureCollection);
-    }
+    // if (this.cumulativeMode && this.cumulativeFeature) {
+    //   const featureCollection = turf.featureCollection([visitedUnion, this.cumulativeFeature].filter(Boolean));
+    //   visitedUnion = turf.union(featureCollection);
+    // }
 
     // 世界全体からvisitedを引いて霧を作る
     const fogPolygon = turf.difference(turf.featureCollection([this.worldFeature, visitedUnion]));
@@ -788,15 +810,165 @@ export default class extends BaseMapController {
     console.log(`[負荷テスト開始] ${massiveHashes.length} 個のGeohashを一括結合します...`);
 
     try {
-      const resultFeature = this.generateFeatureFromGeohashes(massiveHashes, this.visitedGeohashes);
+      // const resultFeature = this.generateFeatureFromGeohashes(massiveHashes, this.visitedGeohashes);
+      this.generateFeatureFromGeohashes(massiveHashes, this.visitedGeohashes);
 
-      this.visitedFeature = resultFeature;
-      this.executeFogClearing(true);
+      // this.visitedFeature = resultFeature;
+      if (USE_WEBGL_FOG) {
+        this.updateRealtimeFogClearing(true)
+      } else {
+        this.executeFogClearing(true)
+      }
 
       console.log('✅ [負荷テスト完了] オーバーフローせずに結合成功');
     } catch (e) {
       console.error("🚨 結合処理でエラー発生:", e);
     }
+  }
+
+  // 累計地図の重さ確認用
+  // 指定地点周辺の geohash を大量に footprint として保存
+  async debugSaveMassiveFootprintsForCumulativeMap(centerLat, centerLng, options = {}) {
+    if (!DEBUG_MODE) return;
+
+    if (!this.tripId) {
+      console.warn("tripId がないため、デバッグ用footprintを保存できません");
+      return;
+    }
+
+    const {
+      offset = 0.005,
+      precision = GEOHASH_PRECISION,
+      step = 10,
+      maxCount = 5000,
+    } = options;
+
+    const minLat = centerLat - offset;
+    const minLng = centerLng - offset;
+    const maxLat = centerLat + offset;
+    const maxLng = centerLng + offset;
+
+    console.log("----- 累計地図デバッグ保存 開始 -----");
+    console.log({
+      centerLat,
+      centerLng,
+      offset,
+      precision,
+      step,
+      maxCount,
+      bbox: { minLat, minLng, maxLat, maxLng },
+    });
+
+    // 範囲内のgeohashを取得
+    const allHashes = ngeohash.bboxes(minLat, minLng, maxLat, maxLng, precision);
+
+    console.log(`[debug] 生成された geohash 数: ${allHashes.length}`);
+
+    // 全部保存すると多すぎるのでstep間隔で間引く
+    const sampledHashes = allHashes
+      .filter((_, index) => index % step === 0)
+      .slice(0, maxCount);
+
+    console.log(`[debug] 保存対象 geohash 数: ${sampledHashes.length}`);
+
+    if (sampledHashes.length === 0) {
+      console.warn("[debug] 保存対象がありません");
+      return;
+    }
+
+    const now = new Date();
+
+    // geohash の中心座標を footprint にする
+    const footprints = sampledHashes.map((hash, index) => {
+      const decoded = ngeohash.decode(hash);
+
+      return {
+        trip_id: this.tripId,
+        latitude: decoded.latitude,
+        longitude: decoded.longitude,
+
+        // 少しずつ時刻をずらす
+        recorded_at: new Date(now.getTime() + index * 1000).toISOString(),
+      };
+    });
+
+    await this.debugBulkCreateFootprints(footprints);
+
+    console.log("----- 累計地図デバッグ保存 終了 -----");
+  }
+
+
+  // デバッグ用ootprints一括保存
+  async debugBulkCreateFootprints(footprints) {
+    const csrfToken = document.querySelector('meta[name="csrf-token"]')?.content;
+
+    if (!csrfToken) {
+      console.error("CSRF token が見つかりません");
+      return;
+    }
+
+    const chunks = this.chunkArray(footprints, DEBUG_BULK_SAVE_CHUNK_SIZE);
+
+    console.log(`[debug] ${footprints.length}件を ${chunks.length} 回に分けて保存します`);
+
+    for (let i = 0; i < chunks.length; i++) {
+      const chunk = chunks[i];
+
+      console.log(`[debug] 保存中 ${i + 1}/${chunks.length}: ${chunk.length}件`);
+
+      try {
+        const response = await fetch(`/api/v1/trips/${this.tripId}/footprints/bulk_create`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "X-CSRF-Token": csrfToken,
+          },
+          credentials: "same-origin",
+          body: JSON.stringify({ footprints: chunk }),
+        });
+
+        let result = null;
+
+        try {
+          result = await response.json();
+        } catch (_) {
+          // JSONで返らないエラー対策
+        }
+
+        if (!response.ok) {
+          console.error(`[debug] 保存失敗 ${i + 1}/${chunks.length}`, {
+            status: response.status,
+            result,
+          });
+          return;
+        }
+
+        console.log(`[debug] 保存成功 ${i + 1}/${chunks.length}`, result);
+
+        // サーバーに一気に投げすぎないため
+        await this.sleep(DEBUG_BULK_SAVE_INTERVAL_MS);
+
+      } catch (error) {
+        console.error(`[debug] 保存中にエラー ${i + 1}/${chunks.length}`, error);
+        return;
+      }
+    }
+  }
+
+  // 配列を指定サイズで分割
+  chunkArray(array, size) {
+    const chunks = [];
+
+    for (let i = 0; i < array.length; i += size) {
+      chunks.push(array.slice(i, i + size));
+    }
+
+    return chunks;
+  }
+
+  sleep(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
   }
 
   // 指定されたGeohashの周辺を晴らす（デバッグ・テスト用）
@@ -806,7 +978,11 @@ export default class extends BaseMapController {
     this.currentLat = lat;
     this.currentRecordTime = new Date().toISOString();
 
-    this.executeFogClearing();
+    if (USE_WEBGL_FOG) {
+      this.updateRealtimeFogClearing()
+    } else {
+      this.executeFogClearing()
+    }
 
     if(this.status === STATUS.RECORDING){
       this.postFootprint();
@@ -885,39 +1061,11 @@ export default class extends BaseMapController {
     this.visitedGeohashes.forEach(hash => this.cumulativeGeohashes.add(hash));
 
     // 累計Featureと今回のFeatureを結合
-    if (this.cumulativeFeature) {
-      this.cumulativeFeature = turf.union(turf.featureCollection([this.cumulativeFeature, this.visitedFeature]));
-    } else {
-      this.cumulativeFeature = turf.clone(this.visitedFeature);
-    }
-  }
-
-  // 累計地図セット
-  setCumulativeGeohashesAndFeature(cumulativeGeohashes){
-    if(this.cumulativeModeStatus === "loading" || this.cumulativeModeStatus === "isReady") return;
-    this.cumulativeModeStatus = "loading"
-
-    return fetch("/api/v1/my_map", { signal: this.ac.signal })
-      .then(res => {
-        if(!res.ok) throw new Error(`HTTP ${res.status}`);
-        return res.json();
-      })
-      .then((data) => {
-        if (this.ac.signal.aborted || !this.element.isConnected) return;
-
-        this.cumulativeFeature = this.generateFeatureFromGeohashes(data.geohashes, cumulativeGeohashes);
-
-        this.cumulativeModeStatus = "isReady"
-      })
-      .catch((e) => {
-        this.cumulativeModeStatus = "notReady"
-        this.uiOutlet.disableCumulative();
-        if (e.name == "AbortError") {
-          console.debug("ページ遷移によるエラー", e);
-          return;
-        }
-        console.error(e);
-      });
+    // if (this.cumulativeFeature) {
+    //   this.cumulativeFeature = turf.union(turf.featureCollection([this.cumulativeFeature, this.visitedFeature]));
+    // } else {
+    //   this.cumulativeFeature = turf.clone(this.visitedFeature);
+    // }
   }
 
   async cumulativeModeOn(){
@@ -933,11 +1081,19 @@ export default class extends BaseMapController {
       }
 
       this.cumulativeMode = true;
-      this.executeFogClearing(true);
+      if (USE_WEBGL_FOG) {
+        this.updateRealtimeFogClearing(true)
+      } else {
+        this.executeFogClearing()
+      }
 
     } else if (this.cumulativeModeStatus === "isReady"){
       this.cumulativeMode = true;
-      this.executeFogClearing(true);
+      if (USE_WEBGL_FOG) {
+        this.updateRealtimeFogClearing(true)
+      } else {
+        this.executeFogClearing()
+      }
     }
   }
 
@@ -948,7 +1104,12 @@ export default class extends BaseMapController {
 
     this.forceStopCumulative = true;
     this.cumulativeMode = false;
-    this.executeFogClearing(true);
+
+    if (USE_WEBGL_FOG) {
+      this.updateRealtimeFogClearing(true)
+    } else {
+      this.executeFogClearing(true)
+    }
   }
 
   geolocateTrigger(){
@@ -982,5 +1143,34 @@ export default class extends BaseMapController {
   dispatchLocationUpdate(){
     window.dispatchEvent(new CustomEvent("location:update", {
     }))
+  }
+
+  updateRealtimeFogClearing(force = false) {
+    const newGeohashes = this.addGeohashesAndGetNew(this.currentGeohash, this.visitedGeohashes)
+
+    if (!force && newGeohashes.length === 0) {
+      console.log("新たに訪れた場所がないのでWebGL霧は更新しません")
+      return
+    }
+
+    this.updateCustomFogLayer()
+
+    if(this.status === STATUS.STOPPED){
+      this.resetFogData()
+    }
+  }
+
+  setupCustomFogLayerEvents() {
+    // moveendとzoomendの両方で実行
+    const updateEvents = ["moveend", "zoomend"];
+
+    updateEvents.forEach(eventType => {
+      this.map.on(eventType, () => {
+        // カスタムレイヤーが存在し、かつ表示中であれば更新する
+        if (this.fogCustomLayer) {
+          this.updateRealtimeFogClearing(true);
+        }
+      });
+    });
   }
 }

--- a/app/javascript/controllers/scroll_reset_controller.js
+++ b/app/javascript/controllers/scroll_reset_controller.js
@@ -3,12 +3,14 @@ import { Controller } from "@hotwired/stimulus"
 // Connects to data-controller="scroll-reset"
 export default class extends Controller {
   connect() {
+    console.log("アイウエオ")
   }
 
   top() {
+    console.log("会う家お")
     this.element.scrollTo({
-      top: 0,
-      behavior: "auto"
+      // top: 0,
+      // behavior: "auto"
     })
   }
 }

--- a/app/javascript/controllers/ui_controller.js
+++ b/app/javascript/controllers/ui_controller.js
@@ -111,7 +111,8 @@ export default class extends Controller {
     this.mapOutlet.postFootprint();
     this.mapOutlet.setFlushTimer();
     this.mapOutlet.addMarkers();
-    this.mapOutlet.executeFogClearing(true);
+    // this.mapOutlet.executeFogClearing(true);
+    this.mapOutlet.updateRealtimeFogClearing(true);
 
     // デバウンスイベントをセット
     this.documentSetHiddenTimer();

--- a/app/views/my_maps/show.html.erb
+++ b/app/views/my_maps/show.html.erb
@@ -32,12 +32,24 @@
       data-style-url="<%= ENV.fetch("STYLE_URL") %>"
       data-history-map-longitude-value="<%= @first_footprint&.longitude %>"
       data-history-map-latitude-value="<%= @first_footprint&.latitude %>"
-      data-history-map-visited-geohashes-value="<%= @visited_geohashes.to_json %>"
+      data-history-map-visited-geohashes-value=""
       data-history-map-posts-value="<%= @posts.to_json %>"
     >
-      <div class="fixed bg-white w-full h-[130%] -bottom-[30%] inset-0 z-20 transition-transform duration-[2000ms] opacity-100 pointer-events-none ease-in-out
-                  [mask-image:linear-gradient(to_bottom,black_80%,transparent)]"
-                  data-history-map-target="mapOverlay"></div>
+
+      <%# オーバレイ要素 %>
+      <div class="fixed w-full h-[130%] -bottom-[30%] inset-0 z-20 transition-transform duration-[2000ms] opacity-100 pointer-events-none ease-in-out
+                  [mask-image:linear-gradient(to_bottom,black_80%,transparent)] animate-fog-twinkle"
+                  data-history-map-target="mapOverlay">
+
+        <%# ロゴ %>
+        <div class="absolute top-0 w-full h-screen flex items-center justify-center pointer-events-none z-[4] -translate-y-8">
+          <%= image_tag "logo-vertical.svg", class: "w-36 sm:w-48 opacity-[0.3] select-none animate-pulse" %>
+        </div>
+
+        <%# 風のように通り過ぎる影の層 %>
+        <div class="absolute inset-0 pointer-events-none animate-wind-sweep"></div>
+      </div>
+
     </div>
   </div>
 </div>

--- a/app/views/shared/_user_records_frame.html.erb
+++ b/app/views/shared/_user_records_frame.html.erb
@@ -43,8 +43,8 @@
   <%# --- メインリスト部分 --- %>
   <div
     class="flex-1 min-h-0 overflow-y-auto overflow-x-hidden pb-28 block w-full"
-    data-controller="scroll-reset"
-    data-action="turbo:frame-load->scroll-reset#top">
+    data-controller="scroll-reset">
+    <%# data-action="turbo:frame-load->scroll-reset#top"> %>
 
     <% if active_tab == :trips %>
       <%= render "trips/list", trips: trips, geohash_counts: geohash_counts %>

--- a/app/views/trips/_list.html.erb
+++ b/app/views/trips/_list.html.erb
@@ -40,7 +40,7 @@
 <% else %>
   <%# 空状態 %>
   <div class="flex flex-col items-center justify-center py-12 text-gray-500 border-b border-gray-200 max-w-2xl mx-auto">
-    <%= lucide_icon('image-off', class: "w-10 h-10 mb-3 text-gray-300") %>
+    <%= lucide_icon('map', class: "w-10 h-10 mb-3 text-gray-300") %>
     <p class="text-sm">地図が存在しません。</p>
   </div>
 <% end %>

--- a/app/views/users/mypage.html.erb
+++ b/app/views/users/mypage.html.erb
@@ -1,7 +1,7 @@
-<div class="h-full pb-20 bg-gray-100 flex justify-center">
+<div class="min-h-dvh pb-20 bg-gray-100 flex justify-center">
 
   <%# 各カードを包むコンテナ %>
-  <div class="max-w-md w-full flex flex-col gap-4 p-4">
+  <div class="max-w-md w-full flex flex-col gap-4 p-4 mb-11">
 
     <%# 規約同意カード %>
     <div class="bg-white rounded-xl shadow-md p-4 mb-4 flex flex-col items-center gap-4">


### PR DESCRIPTION
## issue
- close: #183 

## 実装内容
- WebGLを使用した霧晴れ機能実装
- custom layerを使用して、WebGLの霧晴れ描画を反映
- WebGL霧晴れ機能をmap,history map両方に実装

## issueとの差分
- issue段階では実装方法が不明だったが、WebGLを使用しての霧晴れ機能に決定

## 動作確認方法
- テストで重い地図データを用意して、問題なく描画可能か確認
- 現状の重い本番環境データを、スマホでテストし、重くないことを確認

## 補足
- WebGLでの描画で問題はないが、今後もっと最適な方法がないか模索する
