### PR TITLE
本リリース前最終チェック終了

### DIFF
--- a/app/controllers/my_maps_controller.rb
+++ b/app/controllers/my_maps_controller.rb
@@ -1,7 +1,12 @@
 class MyMapsController < ApplicationController
   def show
-    @first_footprint = current_user&.footprints.first
-    @visited_geohashes = current_user&.cumulative_geohashes || []
-    @posts = current_user&.posts || []
+    if user_signed_in?
+      @first_footprint = current_user&.footprints.first
+      @visited_geohashes = current_user&.cumulative_geohashes || []
+      @posts = current_user&.posts || []
+    else
+      flash[:alert] = "この機能はゲストか会員しか使えません"
+      redirect_to new_user_session_path
+    end
   end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -2,6 +2,8 @@ class PostsController < ApplicationController
   before_action :set_trip, only: %i[ new create select_position ]
 
   def index
+    return unless user_signed_in?
+
     @posts = current_user
                 .posts
                 .includes(:trip, user: { avatar_attachment: :blob })
@@ -42,7 +44,7 @@ class PostsController < ApplicationController
         respond_modal(flash_message: { notice: "地図に記録しました" })
       rescue => e
         Rails.logger.error("Post image attach failed: #{e.class} #{e.message}")
-        purge_cloudflare_urls(media_origin_urls(@post))
+        PurgeCloudflareUrlsJob.perform_later(media_origin_urls(@post))
         @post.destroy
         respond_modal("shared/flash_and_error", locals: { object: @post }, flash_message: { alert: "画像の保存に失敗しました。もう一度お試しください" })
       end

--- a/app/controllers/trips_controller.rb
+++ b/app/controllers/trips_controller.rb
@@ -27,8 +27,8 @@ class TripsController < ApplicationController
       @trips = current_user.trips.order(started_at: :desc)
       @geohash_counts = Footprint.where(trip_id: @trips.select(:id)).group(:trip_id).distinct.count(:geohash)
     else
-      flash[:alert] = "この機能はゲストか会員しか使えません"
-      redirect_to root_path
+      # flash[:alert] = "この機能はゲストか会員しか使えません"
+      # redirect_to root_path
     end
   end
 

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -106,9 +106,9 @@ class Users::RegistrationsController < Devise::RegistrationsController
   end
 
   # DELETE /resource
-  # def destroy
-  #   super
-  # end
+  def destroy
+    redirect_to mypage_path, alert: "退会機能は現在準備中です"
+  end
 
   # GET /resource/cancel
   # Forces the session data which is usually expired after sign

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -38,7 +38,7 @@ class UsersController < ApplicationController
       begin
         if remove_avatar
           @user.avatar.purge
-          purge_cloudflare_url(old_avatar_url)
+          PurgeCloudflareUrlsJob.perform_later(old_avatar_url)
 
         elsif uploaded_file.present?
           @user.avatar.attach(
@@ -48,7 +48,7 @@ class UsersController < ApplicationController
             key: avatar_key(@user, uploaded_file)
           )
 
-          purge_cloudflare_url(old_avatar_url)
+          PurgeCloudflareUrlsJob.perform_later(old_avatar_url)
         end
 
         respond_modal

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -6,7 +6,7 @@ module ApplicationHelper
 
     # mypageからリダイレクトされて開いているユーザー詳細ページもアクティブに
     if user_signed_in?
-      if path == user_path(current_user)
+      if path == mypage_path
         if controller_name == "users" && action_name == "show"
           is_active = true
         end
@@ -22,16 +22,6 @@ module ApplicationHelper
 
   # フッター表示用
   def show_footer?
-    # allowed_paths = [
-    #   root_path,
-    #   trips_path,
-    #   mypage_path
-    # ]
-
-    # if user_signed_in?
-    #   allowed_paths << user_path(current_user)
-    # end
-
     if user_signed_in?
       if controller_name == "users"
         if action_name == "show"
@@ -117,7 +107,7 @@ module ApplicationHelper
   end
 
   def show_history_button?
-    controller_name == "trips" && action_name.in?(%w[show])
+    controller_name == "trips" && action_name.in?(%w[show]) && @trip.user_id == current_user.id
   end
 
   def mypage_card(show_elements)

--- a/app/javascript/controllers/dropdown_controller.js
+++ b/app/javascript/controllers/dropdown_controller.js
@@ -18,7 +18,7 @@ export default class extends Controller {
     const div = document.createElement("div");
     div.className = "my-dropdown-menu absolute top-full right-0 mt-2 w-20 bg-white shadow-lg rounded-md border border-gray-400 z-50 flex flex-col text-black";
     div.innerHTML = `
-      <a href="" class="px-2 py-1 hover:bg-gray-100 rounded">編集</a>
+      <a href="" class="px-2 py-1 hover:bg-gray-100 rounded hidden">編集</a>
       <a href="${url}" data-turbo-stream="true" class="px-2 py-1 hover:bg-gray-100 rounded text-red-500">削除</a>
     `;
 

--- a/app/jobs/purge_cloudflare_urls_job.rb
+++ b/app/jobs/purge_cloudflare_urls_job.rb
@@ -2,7 +2,7 @@ class PurgeCloudflareUrlsJob < ApplicationJob
   queue_as :default
 
   def perform(urls)
-    urls = Array(urls).compact.uniq
+    urls = Array(urls).compact_blank.uniq
     return if urls.blank?
 
     conn = Faraday.new(url: "https://api.cloudflare.com")

--- a/app/models/trip.rb
+++ b/app/models/trip.rb
@@ -28,7 +28,8 @@ class Trip < ApplicationRecord
   # アソシエーション定義
   belongs_to :user
   has_many :footprints, dependent: :destroy
-  has_many :posts, dependent: :nullify
+  has_many :posts, dependent: :destroy
+  # has_many :posts, dependent: :nullify
 
   # 初期値定義
   # 開始時刻はアプリ側の時間を入れる

--- a/app/views/api/v1/trips/update.turbo_stream.erb
+++ b/app/views/api/v1/trips/update.turbo_stream.erb
@@ -1,4 +1,4 @@
-<%= turbo_stream.update "modal-container",
+<%#= turbo_stream.update "modal-container",
       partial: "shared/modal",
       locals: {
         title: "探索を記録しました！",
@@ -15,3 +15,5 @@
           }
         }
       } %>
+
+<%= turbo_stream.update "modal-container", partial: "shared/save_completed_modal", locals: { trip: @trip } %>

--- a/app/views/bottom_sheets/_bottom_sheet.html.erb
+++ b/app/views/bottom_sheets/_bottom_sheet.html.erb
@@ -18,7 +18,8 @@
     <div class="flex flex-col items-start gap-4 pl-8">
 
       <%# タイトル編集ボタン %>
-      <% if @trip && @trip.user_id == current_user&.id %>
+      <%# if @trip && @trip.user_id == current_user&.id %>
+      <% if false %>
         <%= button_to edit_title_trip_path(@trip),
               id: "edit-title-button",
               method: :get,
@@ -43,7 +44,7 @@
           <div class="flex items-center justify-center text-orange-400">
             <%= lucide_icon("share-2") %>
           </div>
-          <span>公開設定・シェア</span>
+          <span>設定・共有</span>
         <% end %>
       <% end %>
 

--- a/app/views/bottom_sheets/_show_post_bottom_sheet.html.erb
+++ b/app/views/bottom_sheets/_show_post_bottom_sheet.html.erb
@@ -39,7 +39,8 @@
       <% end %>
 
       <%# 写真の位置情報を使うボタン %>
-      <% if @trip && @trip.user_id == current_user&.id %>
+      <%# if @trip && @trip.user_id == current_user&.id %>
+      <% if false %>
         <%= button_to edit_status_trip_path(@trip),
               method: :get,
               params: { format: :turbo_stream },

--- a/app/views/contacts/show.turbo_stream.erb
+++ b/app/views/contacts/show.turbo_stream.erb
@@ -9,7 +9,7 @@
     </div>
 
     <%# --- モーダル本体 --- %>
-    <div class="relative flex h-[100dvh] sm:h-auto sm:max-h-[85vh] w-full max-w-2xl flex-col overflow-hidden sm:rounded-xl bg-white shadow-2xl animate-fade-in-up transition-all duration-300"
+    <div class="relative flex h-[100dvh] sm:h-auto sm:max-h-[95dvh] w-full max-w-2xl flex-col overflow-hidden sm:rounded-xl bg-white shadow-2xl animate-fade-in-up transition-all duration-300"
       data-modal-target="modalBox">
 
       <%# ヘッダー %>

--- a/app/views/email_verifications/new.html.erb
+++ b/app/views/email_verifications/new.html.erb
@@ -19,6 +19,8 @@
     <div class="text-lg font-bold text-gray-800 mb-2">メールアドレスの確認</div>
     <div class="text-sm text-gray-600 leading-relaxed">ご入力いただいたメールアドレス宛に、</div>
     <div class="text-sm text-gray-600 leading-relaxed">本登録へ進むための専用リンクをお送りします。</div>
+    <div class="text-sm text-gray-600 leading-relaxed">ゲストユーザーはログイン状態のまま登録すると、</div>
+    <div class="text-sm text-gray-600 leading-relaxed">そのままアカウントが引き継がれます。</div>
   </div>
 
   <%# フォームエリア %>

--- a/app/views/explore/posts/_list.html.erb
+++ b/app/views/explore/posts/_list.html.erb
@@ -39,13 +39,17 @@
                   <%= post.visited_at&.strftime("%Y/%m/%d %H:%M") %>
                 </span>
                 <%# 三点リーダボタン %>
-                <div class="relative shrink-0 -mt-1 -mr-2" data-controller="dropdown" data-dropdown-post-url-value="<%= confirm_destroy_post_path(post) %>">
-                  <button type="button"
-                          class="h-8 w-8 flex items-center justify-center text-gray-400 hover:text-blue-500 hover:bg-blue-50 rounded-full transition"
-                          data-action="click->dropdown#toggle">
-                    <%= lucide_icon('ellipsis', class: "w-5 h-5") %>
-                  </button>
-                </div>
+                <% if post.user_id == current_user&.id %>
+                  <div class="relative shrink-0 -mt-1 -mr-2" data-controller="dropdown" data-dropdown-post-url-value="<%= confirm_destroy_post_path(post) %>">
+                    <button type="button"
+                            class="h-8 w-8 flex items-center justify-center text-gray-400 hover:text-blue-500 hover:bg-blue-50 rounded-full transition"
+                            data-action="click->dropdown#toggle">
+                      <%= lucide_icon('ellipsis', class: "w-5 h-5") %>
+                    </button>
+                  </div>
+                <% else %>
+                  <div class="w-8 shrink-0 -mt-1 -mr-2"></div>
+                <% end %>
               </div>
             </div>
 

--- a/app/views/explore/trips/_list.html.erb
+++ b/app/views/explore/trips/_list.html.erb
@@ -41,16 +41,20 @@
                   <%= trip.started_at&.strftime("%Y/%m/%d %H:%M") %>
                 </span>
                 <%# 三点リーダボタン %>
-                <div class="relative shrink-0 -mt-1 -mr-2">
-                  <%= link_to bottom_sheets_path(trip), class: "h-8 w-8 flex items-center justify-center text-gray-400 hover:text-blue-500 hover:bg-blue-50 rounded-full transition", data: { turbo_stream: true } do %>
-                    <%= lucide_icon('ellipsis', class: "w-5 h-5") %>
-                  <% end %>
-                </div>
+                <% if trip.user_id == current_user&.id %>
+                  <div class="relative shrink-0 -mt-1 -mr-2">
+                    <%= link_to bottom_sheets_path(trip), class: "h-8 w-8 flex items-center justify-center text-gray-400 hover:text-blue-500 hover:bg-blue-50 rounded-full transition", data: { turbo_stream: true } do %>
+                      <%= lucide_icon('ellipsis', class: "w-5 h-5") %>
+                    <% end %>
+                  </div>
+                <% else %>
+                  <div class="w-8 shrink-0 -mt-1 -mr-2"></div>
+                <% end %>
               </div>
             </div>
 
             <%# --- タイトル --- %>
-            <div class="mt-1 text-[15px] font-bold text-gray-900 leading-snug truncate">
+            <div id="<%= "list-map-title-#{trip.public_uid}" %>" class="mt-1 text-[15px] font-bold text-gray-900 leading-snug truncate">
               <%= trip.title %>
             </div>
 

--- a/app/views/posts/_list.html.erb
+++ b/app/views/posts/_list.html.erb
@@ -39,13 +39,15 @@
                   <%= post.visited_at&.strftime("%Y/%m/%d %H:%M") %>
                 </span>
                 <%# 三点リーダボタン %>
-                <div class="relative shrink-0 -mt-1 -mr-2" data-controller="dropdown" data-dropdown-post-url-value="<%= confirm_destroy_post_path(post) %>">
-                  <button type="button"
-                          class="h-8 w-8 flex items-center justify-center text-gray-400 hover:text-blue-500 hover:bg-blue-50 rounded-full transition"
-                          data-action="click->dropdown#toggle">
-                    <%= lucide_icon('ellipsis', class: "w-5 h-5") %>
-                  </button>
-                </div>
+                <% if post.user_id = current_user&.id %>
+                  <div class="relative shrink-0 -mt-1 -mr-2" data-controller="dropdown" data-dropdown-post-url-value="<%= confirm_destroy_post_path(post) %>">
+                    <button type="button"
+                            class="h-8 w-8 flex items-center justify-center text-gray-400 hover:text-blue-500 hover:bg-blue-50 rounded-full transition"
+                            data-action="click->dropdown#toggle">
+                      <%= lucide_icon('ellipsis', class: "w-5 h-5") %>
+                    </button>
+                  </div>
+                <% end %>
               </div>
             </div>
 

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -178,13 +178,21 @@
               <span class="text-xs">履歴</span>
             <% end %>
 
-            <%= link_to explore_trips_path, class: tab_class(tutorial_path) do %>
+            <%= link_to explore_trips_path, class: tab_class(explore_trips_path) do %>
               <%= lucide_icon('users') %>
               <span class="text-xs">みんなの地図</span>
             <% end %>
 
-            <%= link_to mypage_path, class: tab_class(mypage_path) do %>
-              <%= lucide_icon('circle-user-round') %>
+            <%= link_to mypage_path, class: tab_class(mypage_path), id: "tab-bar-icon" do %>
+              <% if current_user&.avatar&.attached? %>
+                <div class="w-6 h-6 rounded-full flex items-center justify-center shadow-md">
+                  <%= image_tag avatar_url(current_user), class: "w-full h-full object-cover rounded-full" %>
+                </div>
+              <% else %>
+                <div class="w-6 h-6 bg-orange-400 rounded-full flex items-center justify-center shadow-md">
+                  <%= lucide_icon('user-round', class: "m-0 w-full h-full text-white") %>
+                </div>
+              <% end %>
               <span class="text-xs">マイページ</span>
             <% end %>
           </nav>

--- a/app/views/shared/_save_completed_modal.html.erb
+++ b/app/views/shared/_save_completed_modal.html.erb
@@ -1,15 +1,42 @@
-<div class="mx-auto mb-4 aspect-square w-full max-w-[280px] bg-white p-2 shadow-sm">
-  <%= image_tag "tutorial_step3.png", class: "h-full w-full object-cover bg-gray-100" %>
-</div>
+<div class="fixed inset-0 h-full pointer-events-none w-full z-40 flex justify-center items-center opacity-0 transition-all duration-300 p-0 sm:p-10" data-controller="modal">
+  <div class="modal-backdrop absolute inset-0 bg-black/50 z-0 pointer-events-auto" data-modal-target="modalBackdrop"></div>
 
-<%= render "shared/visibility_button", trip: trip %>
+  <div class="relative w-full h-[100dvh] sm:h-auto sm:max-w-sm sm:max-h-[95dvh] pointer-events-auto modal-box bg-[#fff9d6] p-4 pt-10 sm:pt-4 gap-3 flex flex-col items-center sm:rounded-[20px] z-10 transition-all duration-500 ease-out shadow-xl translate-y-40 opacity-0" data-modal-target="modalBox">
 
-<%= render "shared/copy_url", trip: trip %>
+    <div id="<%= "completed-map-title-#{trip.public_uid}" %>" class="modal-header shrink-0 z-20 flex justify-between items-center w-full relative">
+      <div class="text-lg font-bold truncate">
+        <%= trip.title %>
+      </div>
+      <div>
+        <%= button_to edit_title_trip_path(trip),
+              method: :get,
+              params: { format: :turbo_stream },
+              form: { class: "contents" },
+              class: "flex items-center gap-3 rounded-full bg-[#FFE4C4] px-3 py-2 text-sm font-medium text-gray-600 transition hover:bg-[#ffd8a8]" do %>
+          <div class="flex items-center justify-center text-orange-400">
+            <%= lucide_icon("square-pen") %>
+          </div>
+        <% end %>
+      </div>
+    </div>
 
-<%= render "shared/share_button", trip: trip %>
+    <%# モーダル本文 %>
+    <div class="modal-body w-full flex-1 min-h-0 px-4 z-20 overflow-y-auto overscroll-contain pb-6 sm:pb-0">
+      <div class="mx-auto mb-4 aspect-square w-full max-w-[280px] bg-white p-2 shadow-sm">
+        <%= image_tag "tutorial_step3.png", class: "h-full w-full object-cover bg-gray-100" %>
+      </div>
 
-<div class="text-center w-full">
-  <button type="button" data-action="click->modal#close click->ui#endRecording" class="rounded-full bg-[#cccaca] px-8 py-2 text-sm font-semibold text-gray-600 shadow-sm transition hover:bg-gray-400 hover:text-white">
-    地図へ戻る
-  </button>
+      <%= render "shared/visibility_button", trip: trip %>
+
+      <%= render "shared/copy_url", trip: trip %>
+
+      <%= render "shared/share_button", trip: trip %>
+
+      <div class="text-center w-full mt-0">
+        <button type="button" data-action="click->modal#close click->ui#endRecording" class="rounded-full bg-[#cccaca] px-8 py-2 text-sm font-semibold text-gray-600 shadow-sm transition hover:bg-gray-400 hover:text-white">
+          地図へ戻る
+        </button>
+      </div>
+    </div>
+  </div>
 </div>

--- a/app/views/shared/_save_completed_modal.html.erb
+++ b/app/views/shared/_save_completed_modal.html.erb
@@ -22,8 +22,14 @@
 
     <%# モーダル本文 %>
     <div class="modal-body w-full flex-1 min-h-0 px-4 z-20 overflow-y-auto overscroll-contain pb-6 sm:pb-0">
-      <div class="mx-auto mb-4 aspect-square w-full max-w-[280px] bg-white p-2 shadow-sm">
-        <%= image_tag "tutorial_step3.png", class: "h-full w-full object-cover bg-gray-100" %>
+      <div class="mx-auto mb-4 aspect-square w-full max-w-[280px] bg-white shadow-sm">
+        <%#= image_tag "tutorial_step3.png", class: "h-full w-full object-cover bg-gray-100" %>
+        <%# ダミーのプレースホルダー %>
+        <div class="h-full w-full flex flex-col items-center justify-center bg-gray-50 text-gray-400">
+          <%#= image_tag "#{request.base_url}/ogp.png" %>
+          <%= lucide_icon('map', class: "w-8 h-8 mb-1 text-gray-300") %>
+          <span class="text-xs font-medium tracking-wider">MAP IMAGE</span>
+        </div>
       </div>
 
       <%= render "shared/visibility_button", trip: trip %>

--- a/app/views/shared/_share_button.html.erb
+++ b/app/views/shared/_share_button.html.erb
@@ -6,7 +6,7 @@
   share_text = "#{text_body}\n#{hashtags}\n#{clean_url}"
 %>
 
-<div class="flex flex-col gap-2" data-controller="share-button" data-share-button-title-value="<%= trip.title %>" data-share-button-text-value="<%= hashtags %>" data-share-button-url-value="<%= share_url %>">
+<div id="<%= "share-button-#{trip.public_uid}" %>" class="flex flex-col gap-2" data-controller="share-button" data-share-button-title-value="<%= trip.title %>" data-share-button-text-value="<%= hashtags %>" data-share-button-url-value="<%= share_url %>">
 
   <div class="text-sm text-gray-400 text-center">※共有すると公開設定が変更されます</div>
   <%= button_to update_status_trip_path(trip, trip: { status: 'unlisted', x: 'post' }),method: :patch, class: "w-full", data: { turbo: true, action: "click->modal#open", share_button_target: "fallbackShare", modal_url_param: "https://x.com/intent/tweet?text=#{u(share_text)}" }, form_class: "w-full" do %>

--- a/app/views/trips/_edit_status.html.erb
+++ b/app/views/trips/_edit_status.html.erb
@@ -1,4 +1,4 @@
-<%= turbo_stream.update "modal-container",
+<%#= turbo_stream.update "modal-container",
       partial: "shared/modal",
       locals: {
         title: "公開設定・シェア",
@@ -15,3 +15,53 @@
           }
         }
       } %>
+
+
+<div class="fixed inset-0 h-full pointer-events-none w-full z-40 flex justify-center items-center opacity-0 transition-all duration-300 p-0 sm:p-10" data-controller="modal">
+  <div class="modal-backdrop absolute inset-0 bg-black/50 z-0 pointer-events-auto" data-modal-target="modalBackdrop" data-action="click->modal#close"></div>
+
+  <div class="relative w-full h-[100dvh] sm:h-auto sm:max-w-sm sm:max-h-[95dvh] pointer-events-auto modal-box bg-[#fff9d6] p-4 pt-10 sm:pt-4 gap-3 flex flex-col items-center sm:rounded-[20px] z-10 transition-all duration-500 ease-out shadow-xl translate-y-40 opacity-0" data-modal-target="modalBox">
+
+    <div id="<%= "completed-map-title-#{@trip.public_uid}" %>" class="modal-header shrink-0 z-20 flex justify-between items-center w-full relative">
+      <div class="text-lg font-bold truncate">
+        <%= @trip.title %>
+      </div>
+      <div>
+        <%= button_to edit_title_trip_path(@trip),
+              method: :get,
+              params: { format: :turbo_stream },
+              form: { class: "contents" },
+              class: "flex items-center gap-3 rounded-full bg-[#FFE4C4] px-3 py-2 text-sm font-medium text-gray-600 transition hover:bg-[#ffd8a8]" do %>
+          <div class="flex items-center justify-center text-orange-400">
+            <%= lucide_icon("square-pen") %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+
+    <%# モーダル本文 %>
+    <div class="modal-body w-full flex-1 min-h-0 px-4 z-20 overflow-y-auto overscroll-contain pb-6 sm:pb-0">
+      <div class="mx-auto mb-4 aspect-square w-full max-w-[280px] bg-white shadow-sm">
+        <%#= image_tag "tutorial_step3.png", class: "h-full w-full object-cover bg-gray-100" %>
+        <%# ダミーのプレースホルダー %>
+        <div class="h-full w-full flex flex-col items-center justify-center bg-gray-50 text-gray-400">
+          <%#= image_tag "#{request.base_url}/ogp.png" %>
+          <%= lucide_icon('map', class: "w-8 h-8 mb-1 text-gray-300") %>
+          <span class="text-xs font-medium tracking-wider">MAP IMAGE</span>
+        </div>
+      </div>
+
+      <%= render "shared/visibility_button", trip: @trip %>
+
+      <%= render "shared/copy_url", trip: @trip %>
+
+      <%= render "shared/share_button", trip: @trip %>
+
+      <div class="text-center w-full mt-0">
+        <button type="button" data-action="click->modal#close click->ui#endRecording" class="rounded-full bg-[#cccaca] px-8 py-2 text-sm font-semibold text-gray-600 shadow-sm transition hover:bg-gray-400 hover:text-white">
+          地図へ戻る
+        </button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/trips/_edit_title.html.erb
+++ b/app/views/trips/_edit_title.html.erb
@@ -1,7 +1,7 @@
 <div id="<%= "map-title-" + @trip&.public_uid %>" class="flex-1 text-center text-xl font-bold text-gray-800 px-2">
   <%= form_with url: update_title_trip_path(@trip), class: "flex items-center gap-3",method: :patch, scope: :trip do |form| %>
     <div class="flex-1 min-w-0">
-      <%= form.text_field :title, maxlength: Trip::TITLE_MAX_LENGTH, class: "w-full text-center py-1 min-w-0" %>
+      <%= form.text_field :title, maxlength: Trip::TITLE_MAX_LENGTH, class: "w-full text-center py-1 min-w-0", autofocus: true %>
     </div>
 
     <%= form.submit "確定", class: "shrink-0 cursor-pointer rounded-full bg-orange-400 px-4 py-1.5 text-sm font-bold text-white shadow transition hover:bg-orange-500 active:scale-95" %>

--- a/app/views/trips/_list.html.erb
+++ b/app/views/trips/_list.html.erb
@@ -41,16 +41,18 @@
                   <%= trip.started_at&.strftime("%Y/%m/%d %H:%M") %>
                 </span>
                 <%# 三点リーダボタン %>
-                <div class="relative shrink-0 -mt-1 -mr-2">
-                  <%= link_to bottom_sheets_path(trip), class: "h-8 w-8 flex items-center justify-center text-gray-400 hover:text-blue-500 hover:bg-blue-50 rounded-full transition", data: { turbo_stream: true } do %>
-                    <%= lucide_icon('ellipsis', class: "w-5 h-5") %>
-                  <% end %>
-                </div>
+                <% if trip.user_id == current_user&.id %>
+                  <div class="relative shrink-0 -mt-1 -mr-2">
+                    <%= link_to bottom_sheets_path(trip), class: "h-8 w-8 flex items-center justify-center text-gray-400 hover:text-blue-500 hover:bg-blue-50 rounded-full transition", data: { turbo_stream: true } do %>
+                      <%= lucide_icon('ellipsis', class: "w-5 h-5") %>
+                    <% end %>
+                  </div>
+                <% end %>
               </div>
             </div>
 
             <%# --- タイトル --- %>
-            <div class="mt-1 text-[15px] font-bold text-gray-900 leading-snug truncate">
+            <div id="<%= "list-map-title-#{trip.public_uid}" %>" class="mt-1 text-[15px] font-bold text-gray-900 leading-snug truncate">
               <%= trip.title %>
             </div>
 

--- a/app/views/trips/edit_title.turbo_stream.erb
+++ b/app/views/trips/edit_title.turbo_stream.erb
@@ -1,4 +1,17 @@
 <% target_id = "map-title-" + @trip.public_uid %>
-<%= turbo_stream.replace target_id, partial: "trips/edit_title" %>
+<%#= turbo_stream.replace target_id, partial: "trips/edit_title" %>
+
+<%= turbo_stream.replace "completed-map-title-#{@trip.public_uid}" do %>
+  <div id="<%= "completed-map-title-#{@trip.public_uid}" %>" class="modal-header shrink-0 z-20 text-center text-xl font-bold text-gray-800 w-full">
+    <%= form_with url: update_title_trip_path(@trip), class: "flex items-center gap-3 w-full", method: :patch, scope: :trip do |form| %>
+      <div class="flex-1 min-w-0">
+        <%= form.text_field :title, maxlength: Trip::TITLE_MAX_LENGTH, class: "w-full text-center py-1 min-w-0 rounded border border-gray-300 focus:ring-orange-400 focus:border-orange-400", autofocus: true %>
+      </div>
+
+      <%= form.submit "確定", class: "shrink-0 cursor-pointer rounded-full bg-orange-400 px-4 py-1.5 text-sm font-bold text-white shadow transition hover:bg-orange-500 active:scale-95" %>
+    <% end %>
+  </div>
+<% end %>
+
 <%= turbo_stream.append "flash", partial: "shared/flash_message" %>
 <%= turbo_stream.append "error-container", partial: "shared/error_messages", locals: { object: @trip } %>

--- a/app/views/trips/show.html.erb
+++ b/app/views/trips/show.html.erb
@@ -16,7 +16,7 @@
 
     <%# 右側の「…」ボタン %>
     <div class="flex-none">
-      <% if @trip %>
+      <% if @trip && @trip.user_id == current_user.id %>
         <%= link_to bottom_sheets_path(@trip), class: "block py-1.5", data: { turbo_stream: true } do %>
           <%= lucide_icon("ellipsis-vertical", class: "transition text-gray-900 hover:text-gray-700 active:scale-95")%>
         <% end %>

--- a/app/views/trips/update_title.turbo_stream.erb
+++ b/app/views/trips/update_title.turbo_stream.erb
@@ -1,3 +1,33 @@
 <% target_id = "map-title-" + @trip.public_uid %>
 <%= turbo_stream.replace target_id, partial: "trips/title" %>
+
+<%= turbo_stream.replace "completed-map-title-#{@trip.public_uid}" do %>
+  <div id="<%= "completed-map-title-#{@trip.public_uid}" %>" class="modal-header shrink-0 z-20 flex justify-between items-center w-full truncate">
+    <div class="text-lg font-bold">
+      <%= @trip.title %>
+    </div>
+    <div>
+      <%= button_to edit_title_trip_path(@trip),
+            method: :get,
+            params: { format: :turbo_stream },
+            form: { class: "contents" },
+            class: "flex items-center gap-3 rounded-full bg-[#FFE4C4] px-3 py-2 text-sm font-medium text-gray-600 transition hover:bg-[#ffd8a8]" do %>
+        <div class="flex items-center justify-center text-orange-400">
+          <%= lucide_icon("square-pen") %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+<% end %>
+
+<%= turbo_stream.replace "list-map-title-#{@trip.public_uid}" do %>
+  <div id="<%= "list-map-title-#{@trip.public_uid}" %>" class="mt-1 text-[15px] font-bold text-gray-900 leading-snug truncate">
+    <%= @trip.title %>
+  </div>
+<% end %>
+
+<%= turbo_stream.replace "share-button-#{@trip.public_uid}" do %>
+  <%= render "shared/share_button", trip: @trip %>
+<% end %>
+
 <%= turbo_stream.append "flash", partial: "shared/flash_message" %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -53,9 +53,9 @@
     <% elsif current_user&.general? || current_user&.admin? %>
       <% user_achievements = [
         tag.span("[累計距離]", class: "") +
-        tag.span("124.5 km / 300 マス", class: "text-gray-900 font-semibold"),
+        tag.span("-- km / -- マス", class: "text-gray-900 font-semibold"),
         tag.span("[開拓エリア]", class: "") +
-        tag.span("東京都、埼玉県", class: "text-gray-900 font-semibold"),
+        tag.span("--", class: "text-gray-900 font-semibold"),
       ] %>
       <%= mypage_card(user_achievements) %>
     <% end %>

--- a/app/views/users/update.turbo_stream.erb
+++ b/app/views/users/update.turbo_stream.erb
@@ -21,3 +21,16 @@
     </div>
   </div>
 <% end %>
+
+<%= turbo_stream.update "tab-bar-icon" do %>
+  <% if current_user&.avatar&.attached? %>
+    <div class="w-6 h-6 rounded-full flex items-center justify-center shadow-md">
+      <%= image_tag avatar_url(current_user), class: "w-full h-full object-cover rounded-full" %>
+    </div>
+  <% else %>
+    <div class="w-6 h-6 bg-orange-400 rounded-full flex items-center justify-center shadow-md">
+      <%= lucide_icon('user-round', class: "m-0 w-full h-full text-white") %>
+    </div>
+  <% end %>
+  <span class="text-xs">マイページ</span>
+<% end %>


### PR DESCRIPTION
- 累計地図のページに、未ログインユーザーが入れないように設定
- userのavatar削除時のcloudflareのpurgeをgood jobで非同期に行うよう設定
- 地図履歴と投稿履歴画面を見ログインでも見られるように変更
- タブバーのアイコンのアクティブ状態を正しく動作するよう修正
- 投稿の編集が実装されていないのに、編集ボタンが出ていたのを表示しないように変更
- 権限がない状態でも編集や削除の三点リーダ等のボタンが表示されていたのを、表示しないように修正
- 地図のタイトルを地図共有・シェア画面と一つにまとめ、地図設定モーダルに変更
