### PR TITLE
Fix/minor bugs

### DIFF
--- a/app/javascript/controllers/base_map_controller.js
+++ b/app/javascript/controllers/base_map_controller.js
@@ -3,13 +3,10 @@ import maplibregl from 'maplibre-gl'
 import 'maplibre-gl/dist/maplibre-gl.css'
 import ngeohash from 'ngeohash';
 import { get } from "@rails/request.js"
-import * as turf from "@turf/turf"
 import { Protocol } from "pmtiles";
 
 // 定数定義
 const INITIAL_ZOOM_LEVEL = 17;    // 初期のズームレベル
-const DEBUG_MODE = false;
-const USE_WEBGL_FOG = true;
 
 // Connects to data-controller="base-map"
 export default class extends Controller {
@@ -37,15 +34,6 @@ export default class extends Controller {
     // 累計地図をセット
     this.cumulativeGeohashes = new Set();
     this.cumulativeFeature = null;
-
-    // 世界を覆う霧のマスク
-    // this.worldFeature = turf.polygon([[
-    //   [-180, 90],
-    //   [-180, -90],
-    //   [180, -90],
-    //   [180, 90],
-    //   [-180, 90]
-    // ]]);
   }
 
   disconnect(_element){
@@ -97,6 +85,30 @@ export default class extends Controller {
       zoom: INITIAL_ZOOM_LEVEL,
       attributionControl: false,
     });
+
+    // webglコンテキストが消失した時のイベント
+    this.map.on('webglcontextrestored', () => {
+      console.warn("WebGL context restored 霧レイヤーを再構築します。");
+
+      // レイヤーを追加するためのチェック関数
+      const addLayerSafely = () => {
+        // 地図の準備が完全に終わっていなければ、再チェックを設定してリターン
+        if (!this.map.isStyleLoaded()) {
+          this.map.once("styledata", addLayerSafely);
+          return;
+        }
+
+        // もしレイヤーが残っていたら削除
+        if (this.map.getLayer("geohash-fog-custom-layer")) {
+          this.map.removeLayer("geohash-fog-custom-layer");
+        }
+
+        this.fogInit(); // 霧を再び初期化
+        this.updateCustomFogLayer(); // 現在の霧の状態を反映
+      };
+
+      addLayerSafely();
+    });
   }
 
   async loadStyleJson(signal){
@@ -140,7 +152,7 @@ export default class extends Controller {
     };
   }
 
-  // 渡されたgeohash配列から、結合済みのFeatureを作って返す
+  // 渡されたgeohash配列から、周囲の解放済み部分を計算してセット
   generateFeatureFromGeohashes(visitedGeohashes = [], targetGeohashesSet) {
     if (visitedGeohashes.length === 0) return null;
 
@@ -150,47 +162,6 @@ export default class extends Controller {
     });
 
     return;
-
-    // geohashから開放するポリゴンの配列を作成
-    const polygonsToMerge = [...targetGeohashesSet].map(hash => this.createPolygonFromGeohash(hash));
-
-    if (polygonsToMerge.length === 1) {
-      return polygonsToMerge[0];
-    }
-
-    // 分割でマージ
-    const chunkSize = 100; // 100個のずつに分ける
-    const intermediatePolygons = []; // 塊を保存する配列
-
-    // 100個ずつ四角形だけをマージして塊を複数作る
-    for (let i = 0; i < polygonsToMerge.length; i += chunkSize) {
-      const chunk = polygonsToMerge.slice(i, i + chunkSize);
-      try {
-        // chunkだけのFeatureCollectionを作ってマージ
-        const mergedChunk = turf.union(turf.featureCollection(chunk));
-        if (mergedChunk) {
-          intermediatePolygons.push(mergedChunk);
-        }
-      } catch (e) {
-        console.warn("Union chunk failed, skipping this chunk...", e);
-      }
-    }
-
-    // 塊たちを一気にマージする
-    try {
-      if (intermediatePolygons.length === 1) {
-        return intermediatePolygons[0];
-      }
-      return turf.union(turf.featureCollection(intermediatePolygons));
-    } catch (e) {
-      console.error("Final union failed, falling back to sequential merge...", e);
-      // マージでエラーになったら雪だるま式でリカバリー
-      let fallbackResult = intermediatePolygons[0];
-      for (let i = 1; i < intermediatePolygons.length; i++) {
-        fallbackResult = turf.union(turf.featureCollection([fallbackResult, intermediatePolygons[i]]));
-      }
-      return fallbackResult;
-    }
   }
 
   addGeohashesAndGetNew(currentGeohash, visitedGeohashes) {
@@ -219,14 +190,6 @@ export default class extends Controller {
     }
 
     return newGeohashes
-  }
-
-  // geohashのポリゴンを作成
-  createPolygonFromGeohash(hash){
-    const [minLat, minLon, maxLat, maxLon] = ngeohash.decode_bbox(hash); // geohashをデコードしてbboxの形式に4点を取得
-    const bbox = [minLon, minLat, maxLon, maxLat]; // turfのbbox用に並び替える
-
-    return turf.bboxPolygon(bbox);
   }
 
   // 投稿モードアクティブ
@@ -277,7 +240,6 @@ export default class extends Controller {
   // postsValueのデータを全てマップに追加
   addMarkers(){
     // データがない場合は何もしない
-    console.log(this.postsValue);
     if(!this.hasPostsValue) return;
     if (!this.postsValue?.length) return
 
@@ -342,48 +304,25 @@ export default class extends Controller {
     get(`/posts/${uid}/preview`, { responseKind: "turbo-stream" });
   }
 
+  getFogConfig() {
+    return {
+      opacity: 0.9,
+      color: [1.0, 1.0, 1.0]
+    };
+  }
+
   // 霧の初期化
   fogInit(){
-    if (USE_WEBGL_FOG){
-      // 文字レイヤー（Symbol）のIDを探す
-      // const layers = this.map.getStyle().layers;
-      // let firstSymbolId = null;
-      // for (const layer of layers) {
-      //   if (layer.type === 'symbol') {
-      //     firstSymbolId = layer.id;
-      //     break;
-      //   }
-      // }
+    const config = this.getFogConfig();
 
-      this.fogCustomLayer = new GeohashFogCustomLayer({
-        id: "geohash-fog-custom-layer",
-        opacity: 0.9,
-      });
+    this.fogCustomLayer = new GeohashFogCustomLayer({
+      id: "geohash-fog-custom-layer",
+      opacity: config.opacity,
+      color: config.color
+    });
 
-      if (!this.map.getLayer('geohash-fog-custom-layer')) {
-        this.map.addLayer(this.fogCustomLayer);
-        // this.map.addLayer(this.fogCustomLayer, firstSymbolId);
-      }
-    } else {
-      if (!this.map.getSource('fog')) {
-        this.map.addSource('fog', {
-          type: 'geojson',
-          data: this.worldFeature
-        });
-      }
-
-      if (!this.map.getLayer('fog-layer')) {
-        this.map.addLayer({
-          id: 'fog-layer',
-          type: "fill",
-          source: 'fog',
-          paint: {
-            "fill-color": "#ffffff",
-            "fill-opacity": 0.9,
-            'fill-antialias': false,
-          }
-        });
-      }
+    if (!this.map.getLayer('geohash-fog-custom-layer')) {
+      this.map.addLayer(this.fogCustomLayer);
     }
   }
 
@@ -407,9 +346,6 @@ export default class extends Controller {
   }
 
   setFogOpacity(opacity){
-    // if(this.map){
-    //   this.map.setPaintProperty('fog-layer', 'fill-opacity', opacity);
-    // }
     if (this.fogCustomLayer) {
       this.fogCustomLayer.opacity = opacity;
       this.map.triggerRepaint(); // 再描画
@@ -429,10 +365,7 @@ export default class extends Controller {
       .then((data) => {
         if (this.ac.signal.aborted || !this.element.isConnected) return;
 
-        // this.cumulativeFeature = this.generateFeatureFromGeohashes(data.geohashes, cumulativeGeohashes);
         this.generateFeatureFromGeohashes(data.geohashes, cumulativeGeohashes);
-
-        // console.log(this.cumulativeFeature)
 
         this.cumulativeModeStatus = "isReady"
       })
@@ -461,11 +394,10 @@ export default class extends Controller {
       this.visitedGeohashes.forEach(hash => merged.add(hash))
     }
 
-    // return this.filterVisibleGeohashes(merged)
     return Array.from(merged)
   }
 
-  // 現在の描画範囲内のgeohashを返す
+  // 現在の描画範囲内のgeohashを返す（現在未使用）
   filterVisibleGeohashes(geohashes) {
     const bounds = this.map.getBounds() // 現在の表示範囲を取得
 
@@ -499,7 +431,7 @@ export default class extends Controller {
   }
 }
 
-
+// WebGLを使ったカスタムレイヤー用のクラス
 class GeohashFogCustomLayer {
   constructor({ id = "geohash-fog-custom-layer", opacity = 0.65, color = [1.0, 1.0, 1.0] } = {}) {
     this.id = id;
@@ -543,10 +475,7 @@ class GeohashFogCustomLayer {
     this.vertexData = this.buildVertexData(this.hashes);
 
     // GPUバッファの更新
-    if (this.gl && this.cellBuffer) {
-      this.gl.bindBuffer(this.gl.ARRAY_BUFFER, this.cellBuffer);
-      this.gl.bufferData(this.gl.ARRAY_BUFFER, this.vertexData, this.gl.DYNAMIC_DRAW);
-    }
+    this.uploadCellBuffer();
   }
 
   // Geohashの配列を三角形ポリゴンの頂点配列に変換。座標は this.anchor からの相対値として計算
@@ -643,6 +572,13 @@ class GeohashFogCustomLayer {
     );
   }
 
+  uploadCellBuffer() {
+    if (!this.gl || !this.cellBuffer) return;
+
+    this.gl.bindBuffer(this.gl.ARRAY_BUFFER, this.cellBuffer);
+    this.gl.bufferData(this.gl.ARRAY_BUFFER, this.vertexData, this.gl.DYNAMIC_DRAW);
+  }
+
   // 毎フレームの描画処理
   render(gl, args) {
     if (!this.cellProgram || !this.fogProgram || !this.visible) return;
@@ -652,7 +588,6 @@ class GeohashFogCustomLayer {
 
     // 行列に対して、アンカー分の移動を適用。相対座標で計算された頂点が正しい位置にレンダリングされる
     this.translateMatrix(matrix, this.anchor.x, this.anchor.y);
-
 
     // ステンシルマスクを「書き込み許可」にする.gl.clear(gl.STENCIL_BUFFER_BIT) が効かない場合があるから
     gl.stencilMask(0xff);
@@ -745,5 +680,22 @@ class GeohashFogCustomLayer {
       throw new Error(error);
     }
     return program;
+  }
+
+  // 削除時の動作
+  onRemove(map, gl) {
+    if (!gl.isContextLost?.()) {
+      if (this.cellBuffer) gl.deleteBuffer(this.cellBuffer);
+      if (this.fullscreenBuffer) gl.deleteBuffer(this.fullscreenBuffer);
+      if (this.cellProgram) gl.deleteProgram(this.cellProgram);
+      if (this.fogProgram) gl.deleteProgram(this.fogProgram);
+    }
+
+    this.cellBuffer = null;
+    this.fullscreenBuffer = null;
+    this.cellProgram = null;
+    this.fogProgram = null;
+    this.gl = null;
+    this.map = null;
   }
 }

--- a/app/javascript/controllers/base_map_controller.js
+++ b/app/javascript/controllers/base_map_controller.js
@@ -26,6 +26,7 @@ export default class extends Controller {
     this.mapInitEnd = false; // 初期化終了フラグ
     this.clearMapOverlayEnd = false; // 初期のマップオーバーレイクリアフラグ
     this.isPostModeActive = false; // 投稿モードの状態管理変数を定義
+    this.mapLoadedOnce = false; // 地図読み込み完了フラグ
     this.markers = {}; // マーカーを保存するオブジェクト
 
     // 前のが残っていた時に備えて最初に消してからアボートコントローラーをセット
@@ -88,6 +89,10 @@ export default class extends Controller {
       attributionControl: false,
     });
 
+    // 地図のスタイル、初期ソースのロード完了
+    this.map.once("load", () => {
+      this.mapLoadedOnce = true;
+    });
     this.map.on("webglcontextrestored", this.handleWebGLContextRestored); // webglコンテキスト消失時にカスタムレイヤーを再設定
     this.map.on("error", this.handleMapError); // 地図読み込み失敗時に、リロードモーダルを表示
   }
@@ -135,9 +140,23 @@ export default class extends Controller {
 
     console.warn("[map:error]", error);
 
-    const isPmtilesByteServingError = message.includes("Server returned no content-length header") || message.includes("HTTP Byte Serving");
+    const isPmtilesByteServingError =
+      message.includes("Server returned no content-length header") ||
+      message.includes("content-length") ||
+      message.includes("HTTP Byte Serving");
 
     if (!isPmtilesByteServingError) return;
+
+    // 地図がロード済みなら、一部タイル取得失敗として扱いモーダルは出さない
+    if (this.mapLoadedOnce) {
+      console.warn("[map:pmtiles-range-error-after-load]", {
+        message,
+        mapLoaded: this.map?.loaded?.(),
+        styleLoaded: this.map?.isStyleLoaded?.()
+      })
+
+      return
+    }
 
     this.showMapLoadErrorModal(); // pmtilesをうまく読み込めなかったときだけエラーを表示
 
@@ -502,12 +521,23 @@ export default class extends Controller {
     modal.dataset.controller = "modal";
 
     modal.innerHTML = `
-      <div class="modal-backdrop absolute inset-0 bg-black/50 z-0 pointer-events-auto"></div>
+      <div
+        class="modal-backdrop absolute inset-0 bg-black/50 z-0 pointer-events-auto"
+        data-action="click->modal#close"
+      ></div>
 
       <div
         class="relative max-w-sm pointer-events-auto modal-box max-h-[90vh] w-full bg-[#fff9d6] p-4 gap-3 flex flex-col items-center rounded-[20px] z-10 transition-all duration-500 ease-out shadow-xl translate-y-40 opacity-0"
         data-modal-target="modalBox"
       >
+        <button
+          type="button"
+          class="absolute right-2 top-2 h-6 w-6 flex items-center justify-center leading-none bg-gray-500/50 rounded-full z-30"
+          data-action="click->modal#close"
+          aria-label="閉じる"
+        >
+          ×
+        </button>
         <div class="modal-header shrink-0 z-20">
           <div class="text-lg font-bold">
             地図の読み込みに失敗しました

--- a/app/javascript/controllers/base_map_controller.js
+++ b/app/javascript/controllers/base_map_controller.js
@@ -4,6 +4,8 @@ import 'maplibre-gl/dist/maplibre-gl.css'
 import ngeohash from 'ngeohash';
 import { get } from "@rails/request.js"
 import { Protocol } from "pmtiles";
+import * as Sentry from "@sentry/browser";
+import { STATUS } from "../constants/status";
 
 // 定数定義
 const INITIAL_ZOOM_LEVEL = 17;    // 初期のズームレベル
@@ -86,35 +88,81 @@ export default class extends Controller {
       attributionControl: false,
     });
 
-    // webglコンテキストが消失した時のイベント
-    this.map.on('webglcontextrestored', () => {
-      console.warn("WebGL context restored 霧レイヤーを再構築します。");
-
-      // レイヤーを追加するためのチェック関数
-      const addLayerSafely = () => {
-        // 地図の準備が完全に終わっていなければ、再チェックを設定してリターン
-        if (!this.map.isStyleLoaded()) {
-          this.map.once("styledata", addLayerSafely);
-          return;
-        }
-
-        // もしレイヤーが残っていたら削除
-        if (this.map.getLayer("geohash-fog-custom-layer")) {
-          this.map.removeLayer("geohash-fog-custom-layer");
-        }
-
-        this.fogInit(); // 霧を再び初期化
-        this.updateCustomFogLayer(); // 現在の霧の状態を反映
-      };
-
-      addLayerSafely();
-    });
+    this.map.on("webglcontextrestored", this.handleWebGLContextRestored); // webglコンテキスト消失時にカスタムレイヤーを再設定
+    this.map.on("error", this.handleMapError); // 地図読み込み失敗時に、リロードモーダルを表示
   }
 
+  // webglコンテキスト消失時に実行するメソッド
+  handleWebGLContextRestored = () => {
+    console.warn("WebGL restored! PMTilesの描画完了を待ってから霧を再構築します...");
+
+    this.restoreFogLayerSafely();
+  }
+
+  // webglのカスタムレイヤーを再構築
+  restoreFogLayerSafely = () => {
+    if (!this.map || !this.element.isConnected) return;
+
+    // カスタムレイヤーを追加するためのチェック関数
+    const addLayerSafely = () => {
+      if (!this.map || !this.element.isConnected) return;
+
+      // 地図の準備が完全に終わっていなければ、完了後に再度実行
+      // map.isStyleLoaded(),map.once('styledata', ...)では霧が表示されないので注意
+      if (!this.map.loaded()) {
+        this.map.once("idle", addLayerSafely);
+        return;
+      }
+
+      const layerId = "geohash-fog-custom-layer";
+
+      // もしレイヤーが残っていたら削除
+      if (this.map.getLayer(layerId)) {
+        this.map.removeLayer(layerId);
+      }
+
+      this.fogInit(); // 霧を再び初期化
+      this.updateCustomFogLayer(); // 現在の霧の状態を反映
+    };
+
+    addLayerSafely();
+  }
+
+  // maplibreのエラー時に実行するメソッド
+  handleMapError = (event) => {
+    const error = event.error;
+    const message = error?.message || "";
+
+    console.warn("[map:error]", error);
+
+    const isPmtilesByteServingError = message.includes("Server returned no content-length header") || message.includes("HTTP Byte Serving");
+
+    if (!isPmtilesByteServingError) return;
+
+    this.showMapLoadErrorModal(); // pmtilesをうまく読み込めなかったときだけエラーを表示
+
+    // sentryにエラーを送る
+    if (Sentry) {
+      Sentry.captureException(error || new Error(message), {
+        tags: {
+          area: "map",
+          source: "maplibre",
+          kind: "pmtiles-byte-serving",
+        },
+        extra: {
+          message,
+          url: location.href,
+          userAgent: navigator.userAgent,
+        },
+      });
+    }
+  }
+
+  // stylejsonを読み込む
   async loadStyleJson(signal){
     if(this.constructor.styleJsonCache) {
       console.log("前回のを使用")
-      return structuredClone(this.constructor.styleJsonCache);
+      return structuredClone(this.constructor.styleJsonCache); // 前回読み込んだキャッシュが残っていたらそれを返す
     }
 
     const styleUrl = this.element.dataset.styleUrl;
@@ -168,19 +216,7 @@ export default class extends Controller {
     if(!currentGeohash) return [];
 
     const newGeohashes = [];
-    const candidates = new Set();
-
-    candidates.add(currentGeohash);
-
-    // 現在地の周囲8つのgeohashを取得
-    const neighbors = ngeohash.neighbors(currentGeohash);
-    neighbors.forEach(hash => candidates.add(hash));
-
-    // 周囲8つのさらに周りのgeohashを取得
-    for (const hash of neighbors) {
-      const aroundNeighbors = ngeohash.neighbors(hash);
-      aroundNeighbors.forEach(hash => candidates.add(hash));
-    }
+    const candidates = this.getClearingAreaGeohashes(currentGeohash); // 追加するgeohashの候補を取得
 
     // 保持していないものを追加
     for (const hash of candidates) {
@@ -189,7 +225,26 @@ export default class extends Controller {
       newGeohashes.push(hash);
     }
 
-    return newGeohashes
+    return newGeohashes;
+  }
+
+  getClearingAreaGeohashes(geohash){
+    const candidates = new Set();
+
+    // 現在地自身を追加
+    candidates.add(geohash);
+
+    // 現在地の周囲8つのgeohashを取得
+    const neighbors = ngeohash.neighbors(geohash);
+    neighbors.forEach(hash => candidates.add(hash));
+
+    // 周囲8つのさらに周りのgeohashを取得
+    for (const hash of neighbors) {
+      const aroundNeighbors = ngeohash.neighbors(hash);
+      aroundNeighbors.forEach(hash => candidates.add(hash));
+    }
+
+    return candidates;
   }
 
   // 投稿モードアクティブ
@@ -339,10 +394,17 @@ export default class extends Controller {
   updateCustomFogLayer() {
     if (!this.fogCustomLayer) return
 
-    const visibleHashes = this.getVisibleClearedGeohashes()
+    let visibleHashes = this.getVisibleClearedGeohashes(); // 解放済みのgeohashを取得
 
-    this.fogCustomLayer.setHashes(visibleHashes)
-    this.map.triggerRepaint()
+    // 停止モードの時はvisibleHashesを現在地周辺のみにする
+    // webglコンテキストロスト時に、visitedGeohashが存在しないため、currentGeohashから再計算
+    if (this.currentGeohash && this.status === STATUS.STOPPED) {
+      const currentGeohashes = Array.from(this.getClearingAreaGeohashes(this.currentGeohash));
+      visibleHashes = currentGeohashes;
+    }
+
+    this.fogCustomLayer.setHashes(visibleHashes); // カスタムレイヤーにgeohashをセット
+    this.map.triggerRepaint(); // 地図を再描画
   }
 
   setFogOpacity(opacity){
@@ -428,6 +490,53 @@ export default class extends Controller {
       this.fogCustomLayer.color = [r / 255, g / 255, b / 255];
       this.map.triggerRepaint();
     }
+  }
+
+  // マップ読み込みエラー時のモーダル表示
+  showMapLoadErrorModal() {
+    const container = document.getElementById("modal-container");
+    if (!container) return;
+
+    const modal = document.createElement("div");
+    modal.className = "fixed inset-0 h-full pointer-events-none w-full z-40 flex justify-center items-center opacity-0 transition-all duration-300 p-10";
+    modal.dataset.controller = "modal";
+
+    modal.innerHTML = `
+      <div class="modal-backdrop absolute inset-0 bg-black/50 z-0 pointer-events-auto"></div>
+
+      <div
+        class="relative max-w-sm pointer-events-auto modal-box max-h-[90vh] w-full bg-[#fff9d6] p-4 gap-3 flex flex-col items-center rounded-[20px] z-10 transition-all duration-500 ease-out shadow-xl translate-y-40 opacity-0"
+        data-modal-target="modalBox"
+      >
+        <div class="modal-header shrink-0 z-20">
+          <div class="text-lg font-bold">
+            地図の読み込みに失敗しました
+          </div>
+        </div>
+
+        <div class="modal-body w-full flex-1 min-h-0 px-4 z-20 overflow-y-auto overscroll-contain text-sm leading-relaxed">
+          <p>
+            地図データの読み込みに失敗しました。通信状況を確認して、ページを再読み込みしてください。
+          </p>
+
+          <div class="mt-4 flex justify-center">
+            <button
+              type="button"
+              class="map-error-reload-button rounded-full bg-orange-400 px-4 py-2 text-white font-bold shadow"
+            >
+              再読み込み
+            </button>
+          </div>
+        </div>
+      </div>
+    `;
+
+    container.appendChild(modal);
+
+    const reloadButton = modal.querySelector(".map-error-reload-button");
+    reloadButton?.addEventListener("click", () => {
+      window.location.reload();
+    });
   }
 }
 

--- a/app/javascript/controllers/history_map_controller.js
+++ b/app/javascript/controllers/history_map_controller.js
@@ -1,10 +1,7 @@
 import BaseMapController from "./base_map_controller.js"
 import maplibregl from 'maplibre-gl'
 import 'maplibre-gl/dist/maplibre-gl.css'
-import * as turf from "@turf/turf"
 import ngeohash from 'ngeohash'
-
-const USE_WEBGL_FOG = true;
 
 // Connects to data-controller="history-map"
 export default class extends BaseMapController {
@@ -13,11 +10,9 @@ export default class extends BaseMapController {
                   }
 
   async connect(_element) {
-    // base mapのconnectを実行
-    super.connect();
+    super.connect(); // base mapのconnectを実行
 
     await this.initVisitedGeohashes();
-    // this.cumulativeFeature = this.generateFeatureFromGeohashes(this.visitedGeohashesValue, this.cumulativeGeohashes);
 
     // 中央位置設定
     if(this.longitudeValue && this.latitudeValue){
@@ -38,38 +33,15 @@ export default class extends BaseMapController {
 
     // 非表示にする地図上の情報
     const toHide = [
-      // "Restaurant and shop",
-      // "Store and mall",
-      // "Pub",
-      // "Hotel",
-      // "Generic POI",
-      // "Generic POI 11",
-      // "Major POI",
-      // "Doctor",
-      // "Parking",
-      // "Government",
-      // "Golf pitch",
     ];
 
     // 地図の読み込みが終わった後に実行
     this.map.on('load', () => {
       // 霧を初期化
       this.fogInit();
-      this.setFogOpacity(0.6);
-      this.setFogColor(26, 38, 52)
-      this.setupCustomFogLayerEvents()
+      this.setupCustomFogLayerEvents();
 
-      // toHide.forEach(id => {
-      //   if (this.map.getLayer(id)) {
-      //     this.map.setLayoutProperty(id, "visibility", "none");
-      //   }
-      // });
-
-      // this.executeFogClearing();
       this.updateCustomFogLayer();
-
-      // this.initRevealedAreaLayer();
-      // this.updateRevealedArea();
 
       this.addMarkers();
 
@@ -88,20 +60,11 @@ export default class extends BaseMapController {
     }
   }
 
-  executeFogClearing(){
-    if(!this.cumulativeFeature){
-      console.log("geohashがないので何も実行しません")
-      return;
-    }
-
-    // 世界全体からvisitedを引いて霧を作る
-    const fogPolygon = turf.difference(turf.featureCollection([ this.worldFeature, this.cumulativeFeature ]));
-
-    if (fogPolygon) {
-      this.updateFog(fogPolygon);
-    } else {
-      console.log("fogPolygonが見つかりません");
-    }
+  getFogConfig() {
+    return {
+      opacity: 0.6,
+      color: [26/255, 38/255, 52/255]
+    };
   }
 
   clearMapOverlay(){
@@ -141,96 +104,6 @@ export default class extends BaseMapController {
     this.maybeClearOverlay();
   }
 
-  // 霧の初期化
-  // fogInit(){
-  //   if (USE_WEBGL_FOG){
-  //     this.fogCustomLayer = new GeohashFogCustomLayer({
-  //       id: "geohash-fog-custom-layer",
-  //       opacity: 0.65,
-  //     })
-
-  //     if (!this.map.getLayer('geohash-fog-custom-layer')) {
-  //       this.map.addLayer(this.fogCustomLayer)
-  //     }
-
-  //   } else {
-  //     if (!this.map.getSource('fog')) {
-  //       this.map.addSource('fog', {
-  //         type: 'geojson',
-  //         data: this.worldFeature
-  //       });
-  //     }
-
-  //     if (!this.map.getLayer('fog-layer')) {
-  //       this.map.addLayer({
-  //         id: 'fog-layer',
-  //         type: "fill",
-  //         source: 'fog',
-  //         paint: {
-  //           "fill-color": "#f2eee8",
-  //           "fill-opacity": 0.55,
-  //           'fill-antialias': false,
-  //         }
-  //       });
-  //     }
-  //   }
-  // }
-
-  initRevealedAreaLayer() {
-    if (!this.map.getSource('revealed-area')) {
-      this.map.addSource('revealed-area', {
-        type: 'geojson',
-        data: this.cumulativeFeature || turf.featureCollection([])
-      });
-    }
-
-    // ふわっとした外側の光
-    if (!this.map.getLayer('revealed-outline-glow')) {
-      this.map.addLayer({
-        id: 'revealed-outline-glow',
-        type: 'line',
-        source: 'revealed-area',
-        paint: {
-          'line-color': '#8b6b4a',
-          'line-opacity': 0.1,
-          'line-width': [
-            'interpolate', ['linear'], ['zoom'],
-            10, 2,
-            14, 4,
-            17, 6
-          ],
-          'line-blur': 3
-        }
-      });
-    }
-
-    // くっきりした境界線
-    if (!this.map.getLayer('revealed-outline')) {
-      this.map.addLayer({
-        id: 'revealed-outline',
-        type: 'line',
-        source: 'revealed-area',
-        paint: {
-          'line-color': '#ad8d6c',
-          'line-opacity': 0.5,
-          'line-width': [
-            'interpolate', ['linear'], ['zoom'],
-            10, 1,
-            14, 1,
-            17, 2
-          ]
-        }
-      });
-    }
-  }
-
-  updateRevealedArea() {
-    const source = this.map.getSource('revealed-area');
-    if (!source) return;
-
-    source.setData(this.cumulativeFeature || turf.featureCollection([]));
-  }
-
   setupCustomFogLayerEvents() {
     // moveendとzoomendの両方で実行
     const updateEvents = ["moveend", "zoomend"];
@@ -245,6 +118,7 @@ export default class extends BaseMapController {
     });
   }
 
+  // 地図の全体が映るようにカメラを設定
   fitToVisitedArea() {
     if (!this.visitedGeohashes || this.visitedGeohashes.size === 0) return;
 

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -19,7 +19,7 @@ const PERMISSION_DENIED     = 1;     // 位置情報不許可時のerror値
 const INITIAL_ZOOM_LEVEL = 17;
 const MAX_POSITION_AGE_MS = 15000; // 位置情報を反映させるのに許容する時間の差
 const MAX_EXPLORATION_ACCURACY = 300; // 霧解放時に許容する現在地の正確さ
-const RESUME_IGNORE_MS = 3000; // ブラウザ復帰時に位置を反映させない時間
+const RESUME_IGNORE_MS = 5000; // ブラウザ復帰時に位置を反映させない時間
 
 // Connects to data-controller="map"
 export default class extends BaseMapController {
@@ -598,6 +598,11 @@ export default class extends BaseMapController {
       this.geolocate = null;
     }
 
+    if (this.map) {
+      this.map.off("error", this.handleMapError);
+      this.map.off("webglcontextrestored", this.handleWebGLContextRestored);
+    }
+
     if (this.resumeIgnoreTimer) {
       clearTimeout(this.resumeIgnoreTimer);
       this.resumeIgnoreTimer = null;
@@ -628,6 +633,12 @@ export default class extends BaseMapController {
     }
     this.mapInitEnd = false;
     this.ac?.abort()
+
+    if (this.map) {
+      this.map.remove(); // 地図機能の停止、削除
+      this.map = null; // 参照も切る
+      console.log("map 消去:", this.map)
+    }
   }
 
   // 要素削除時に起動

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -3,8 +3,8 @@ import { STATUS } from "../constants/status"
 import maplibregl from 'maplibre-gl'
 import 'maplibre-gl/dist/maplibre-gl.css'
 import ngeohash from 'ngeohash';
+import { get } from "@rails/request.js"
 import { getDistance } from 'geolib'
-import * as turf from "@turf/turf"
 
 // 定数定義
 const GEOHASH_PRECISION     = 9;     // 保存するgeohash精度
@@ -17,10 +17,9 @@ const GEOLOCATE_MAXIMUM_AGE = 86400000;  // 位置情報のキャッシュ許容
 const GEOLOCATE_TIMEOUT     = 10000;
 const PERMISSION_DENIED     = 1;     // 位置情報不許可時のerror値
 const INITIAL_ZOOM_LEVEL = 17;
-const DEBUG_MODE = false;
-const DEBUG_BULK_SAVE_CHUNK_SIZE = 500;
-const DEBUG_BULK_SAVE_INTERVAL_MS = 200;
-const USE_WEBGL_FOG = true
+const MAX_POSITION_AGE_MS = 15000; // 位置情報を反映させるのに許容する時間の差
+const MAX_EXPLORATION_ACCURACY = 300; // 霧解放時に許容する現在地の正確さ
+const RESUME_IGNORE_MS = 3000; // ブラウザ復帰時に位置を反映させない時間
 
 // Connects to data-controller="map"
 export default class extends BaseMapController {
@@ -47,7 +46,6 @@ export default class extends BaseMapController {
     this.cumulativeMode = false;
     this.cumulativeModeStatus = "notReady";
     this.forceStopCumulative = false;
-    // this.setCumulativeGeohashesAndFeature(this.cumulativeGeohashes);
 
     // 地図の設定
     this.status = STATUS.STOPPED; // 地図のステータスを初期化
@@ -60,6 +58,10 @@ export default class extends BaseMapController {
     this.lastSentGeohash = ""; // 最後に保存したgeohashを覚えておく変数
     this.lastSavedCoords = null; // 最後に保存した座標
     this.footprintBuffer = []; // データを溜めておくための配列
+    this.ignoreExplorationUntil = 0; // 非表示から復帰した時間を覚えておく変数
+    this.pendingExplorationData = null; // 非表示から復帰した時のデータを覚えておく変数
+    this.resumeIgnoreTimer = null; // 非表示から復帰した時のデータを保存するまでのタイマー
+    this.isFlushing = false; // flushBuffer重複防止フラグ
 
     // geohash、霧関係の設定
     this.visitedFeature = null; // 開放済みの場所をFeatureオブジェクトで管理
@@ -143,6 +145,8 @@ export default class extends BaseMapController {
   // 現在地追従をオフ
   disableGeolocateTracking() {
     if (this.geolocate) {
+      // MapLibre GeolocateControl の private API をいじっている
+      // バージョンアップ時に _watchState,_geolocateButton の仕様変更で壊れる可能性があるため要確認
       if (this.geolocate._watchState === 'ACTIVE_LOCK') { // ACTIVE_LOCK,追従中の時に
         this.geolocate._watchState = 'BACKGROUND'; // 強制的にBACKGROUNDに書き換える
 
@@ -202,23 +206,12 @@ export default class extends BaseMapController {
   setupMapLoadEvents() {
     // 非表示にする地図上の情報
     const toHide = [
-      // "Restaurant and shop",
-      // "Store and mall",
-      // "Pub",
-      // "Hotel",
-      // "Generic POI",
-      // "Generic POI 11",
-      // "Major POI",
-      // "Doctor",
-      // "Parking",
-      // "Government",
-      // "Golf pitch",
     ];
 
     // 地図の読み込みが終わった後に実行
     this.map.on('load', () => {
       this.fogInit(); // 霧を初期化
-      this.setupCustomFogLayerEvents()
+      // this.setupCustomFogLayerEvents()
 
       // toHide配列の中身のidの要素を透過
       toHide.forEach(id => {
@@ -228,33 +221,6 @@ export default class extends BaseMapController {
       });
 
       this.checkLocationPermissions(); // 規約と位置情報をチェックして現在地追従オン
-
-      // デバッグ用：クリックで霧を晴らす
-      if(DEBUG_MODE){
-        this.map.on('click', (e) => {
-          const { lng, lat } = e.lngLat; // クリックした箇所のlng,latを取得
-
-          // e.originalEvent.altKey で Alt(Option)キーが押されているか判定
-          if (e.originalEvent.altKey && e.originalEvent.metaKey) {
-            console.log(`[累計地図デバッグ保存] ${lat}, ${lng} 周辺のfootprintsを大量保存します`);
-
-            this.debugSaveMassiveFootprintsForCumulativeMap(lat, lng, {
-              offset: 0.01,
-              precision: 9,
-              step: 20,
-              maxCount: 10000,
-            });
-          } else if (e.originalEvent.altKey) {
-            console.log(`[負荷テスト] ${lat}, ${lng} 周辺を一括開放します`);
-            this.debugClearMassiveFog(lat, lng);
-          } else {
-            // 通常の1箇所開放
-            const clickHash = ngeohash.encode(lat, lng, 9);
-            console.log(`クリック地点: ${lat}, ${lng} -> ${clickHash}`);
-            this.debugClearFogAt(clickHash, lng, lat);
-          }
-        });
-      }
     });
 
     // アイコンが足りない時のダミー追加
@@ -284,6 +250,8 @@ export default class extends BaseMapController {
       // 移動が終わったら一回だけ起動
       this.map.once('moveend', () => {
         if (this.geolocate) {
+          // MapLibre GeolocateControl の private API をいじっている
+          // バージョンアップ時に _watchState,_geolocateButton の仕様変更で壊れる可能性があるため要確認
           if (this.geolocate._watchState === 'BACKGROUND') {
             this.geolocate._watchState = 'ACTIVE_LOCK'; // geolocateの状態を追従モードへ
             const btn = this.geolocate._geolocateButton;
@@ -308,6 +276,11 @@ export default class extends BaseMapController {
   handleGeolocate = (data) => {
     if (!this.map || !this.element.isConnected) return; // ガード
 
+    this.updateCurrentPositionState(data);
+    this.applyGeolocateForExploration(data);
+  }
+
+  updateCurrentPositionState(data){
     // 各種データの取得
     const lng = data.coords.longitude; // 経度
     const lat = data.coords.latitude;  // 緯度
@@ -326,24 +299,60 @@ export default class extends BaseMapController {
 
     this.pulseMarker.setLngLat([this.currentLng, this.currentLat]); // 自作パルスの現在地を更新
 
-    // 霧の更新
-    if (this.status !== STATUS.PAUSED) {
-      if (USE_WEBGL_FOG) {
-        this.updateRealtimeFogClearing()
-      } else {
-        this.executeFogClearing()
-      }
+    this.mapInitEnd = true; // 地図初期化完了
+    this.maybeClearOverlay(); // オーバーレイ要素をクリア
+    this.dispatchLocationUpdate(); // location:updateイベントを発火
+  }
+
+  applyGeolocateForExploration(data){
+    // 一時停止中なら、保存も霧解放もしない
+    if (this.status === STATUS.PAUSED) return;
+
+    // 復帰直後や精度不良なら、保存も霧解放もしない
+    if (!this.canUseForExploration(data)) {
+      console.log("探索用対象外なので霧も保存も反映しません");
+      return;
     }
 
-    this.mapInitEnd = true;
-    this.maybeClearOverlay();
+    // タイマーが存在する時はクリア
+    if (this.resumeIgnoreTimer) {
+      clearTimeout(this.resumeIgnoreTimer);
+      this.resumeIgnoreTimer = null;
+    }
 
-    this.dispatchLocationUpdate(); // location:updateイベントを発火
+    // 霧の更新
+    this.updateRealtimeFogClearing();
 
     // status が RECORDING になっている場合に保存判定
     if(this.status === STATUS.RECORDING) {
       this.checkAndBufferFootprint(this.currentGeohash);
     }
+  }
+
+  // Footprintを判定
+  canUseForExploration(data) {
+    // 非表示から復帰直後は安定しないため反映させない
+    if (Date.now() < this.ignoreExplorationUntil) {
+      console.log("復帰直後なので探索反映をスキップ");
+      this.pendingExplorationData = data;
+      return false;
+    }
+
+    // 保存・霧解放には古いキャッシュ位置を使わない
+    const ageMs = Date.now() - data.timestamp;
+    if (ageMs > MAX_POSITION_AGE_MS) {
+      console.warn("古い位置情報なので探索反映をスキップ", ageMs);
+      return false;
+    }
+
+    // 精度が悪い位置情報は使わない
+    const accuracy = data.coords.accuracy;
+    if (accuracy != null && accuracy > MAX_EXPLORATION_ACCURACY) {
+      console.warn("精度が悪い位置情報なので探索反映をスキップ", accuracy);
+      return false;
+    }
+
+    return true;
   }
 
   // 位置情報と規約の状態をチェックして地図表示とオーバーレイを晴らす
@@ -464,7 +473,29 @@ export default class extends BaseMapController {
   onVisibilityChange = () => {
     if(document.visibilityState === 'hidden' && this.status === STATUS.RECORDING){
       this.flushBuffer();
-      this.postFootprint();
+      // this.postFootprint();
+    }
+
+    // ページが表示中に戻ったときに
+    if (document.visibilityState === 'visible') {
+      this.ignoreExplorationUntil = Date.now() + RESUME_IGNORE_MS;
+
+      // タイマーが存在する時はクリア
+      if (this.resumeIgnoreTimer) {
+        clearTimeout(this.resumeIgnoreTimer);
+      }
+
+      // 復帰時のデータを保存するまでのタイマー
+      this.resumeIgnoreTimer = setTimeout(() => {
+        this.resumeIgnoreTimer = null;
+
+        if (!this.pendingExplorationData) return;
+
+        const data = this.pendingExplorationData;
+        this.pendingExplorationData = null;
+
+        this.applyGeolocateForExploration(data);
+      }, RESUME_IGNORE_MS + 100); // 少しだけ時間をずらす
     }
   }
 
@@ -567,6 +598,12 @@ export default class extends BaseMapController {
       this.geolocate = null;
     }
 
+    if (this.resumeIgnoreTimer) {
+      clearTimeout(this.resumeIgnoreTimer);
+      this.resumeIgnoreTimer = null;
+    }
+    this.pendingExplorationData = null;
+
     this.uiOutlet.cumulativeModeOff();
     // 自作マーカーを削除
     if (this.pulseMarker) {
@@ -577,11 +614,8 @@ export default class extends BaseMapController {
     if(this.flushTimer) {
       clearInterval(this.flushTimer);
       this.flushTimer = null;
-      this.flushBuffer();
     }
-    if(this.status === STATUS.RECORDING){
-      this.postFootprint();
-    }
+    this.flushBuffer();
     if(this.overlayTimer){
       clearTimeout(this.overlayTimer);
       this.overlayTimer = null;
@@ -627,7 +661,6 @@ export default class extends BaseMapController {
     this.tripId = id;
     if(oldVisitedGeohashes){
       this.visitedGeohashes.clear();
-      // this.visitedFeature = this.generateFeatureFromGeohashes(oldVisitedGeohashes, this.visitedGeohashes);
       this.generateFeatureFromGeohashes(oldVisitedGeohashes, this.visitedGeohashes);
     }
   }
@@ -638,7 +671,9 @@ export default class extends BaseMapController {
   }
 
   // 単発のfootprint保存
+  // 注意: 今は基本的には使わない
   async postFootprint() {
+    if (!this.tripId || !this.currentLat || !this.currentLng || !this.currentRecordTime) return;
     console.log("postFootprint起動")
     const csrfToken = document.querySelector('meta[name="csrf-token"]').content
 
@@ -672,6 +707,18 @@ export default class extends BaseMapController {
     console.log("postFootprint:位置情報の保存に成功しました");
   }
 
+  // 開始時の現在地を保存
+  recordStartFootprint() {
+    if (!this.tripId || !this.currentLat || !this.currentLng || !this.currentRecordTime || !this.currentGeohash) {
+      console.warn("現在地が未取得なので開始地点を保存しません");
+      return;
+    }
+
+    const now = Date.now();
+    this.addFootprintToBuffer(now, this.currentGeohash);
+    this.flushBuffer();
+  }
+
   // 溜めたバッファを送信するためのフラッシュタイマー
   setFlushTimer(){
     console.log("バッファ送信用タイマーをセット")
@@ -682,16 +729,18 @@ export default class extends BaseMapController {
 
   // 溜めたバッファを一気にポスト
   async flushBuffer(){
-    if(!this.footprintBuffer?.length) return;
-    console.log("現在地を送信");
+    if(!this.footprintBuffer?.length || this.isFlushing) return;
 
-    const csrfToken = document.querySelector('meta[name="csrf-token"]').content
+    this.isFlushing = true; // バッファ送信中フラグをture
 
-    // データ送信用の浅いコピーを作成
-    const dataToSend = [...this.footprintBuffer];
+    const dataToSend = [...this.footprintBuffer]; // データ送信用の浅いコピーを作成
+    this.footprintBuffer = []; // バッファをクリアしておく
 
     try {
       console.log(`${dataToSend.length}件のデータを送信中...`);
+
+      const csrfToken = document.querySelector('meta[name="csrf-token"]').content
+
       const response = await fetch(`/api/v1/trips/${this.tripId}/footprints/bulk_create`, {
         method: "POST",
         headers: {
@@ -704,23 +753,26 @@ export default class extends BaseMapController {
       })
 
       const result = await response.json()
-      console.log(result)
 
-      // 保存失敗時はエラー
-      if(!response.ok) throw new Error("footprints一括送信失敗");
+      if(!response.ok) throw new Error("footprints一括送信失敗"); // 保存失敗時はエラー
 
       // 保存成功次はバッファをクリア
       this.footprintBuffer = this.footprintBuffer.filter(item => !dataToSend.includes(item));
       console.log("送信成功。現在のバッファ:", this.footprintBuffer);
     } catch(error) {
       console.warn("送信失敗。データを保持して次回リトライします", error);
+
+      this.footprintBuffer = [...dataToSend, ...this.footprintBuffer]; // 失敗したら送れなかった分を先頭に戻す
+    } finally {
+      this.isFlushing = false; // 送信終了後はフラグをfalseに
     }
   }
 
   clearFlushTimer(){
     if(this.flushTimer) {
-      console.log("flushTimerを停止")
       clearInterval(this.flushTimer);
+      this.flushTimer = null;
+      console.log("flushTimerを停止")
     }
   }
 
@@ -734,11 +786,7 @@ export default class extends BaseMapController {
     this.visitedFeature = null;
     this.visitedGeohashes.clear();
 
-    if (USE_WEBGL_FOG) {
-      this.updateRealtimeFogClearing(true)
-    } else {
-      this.executeFogClearing(true)
-    }
+    this.updateRealtimeFogClearing(true)
 
     Object.values(this.markers).forEach(marker => {
       marker.remove();
@@ -749,244 +797,6 @@ export default class extends BaseMapController {
   resetFogData() {
     this.visitedFeature = null;
     this.visitedGeohashes.clear();
-  }
-
-  executeFogClearing(force = false){
-    // console.log("execute実行")
-    const newGeohashes = this.addGeohashesAndGetNew(this.currentGeohash, this.visitedGeohashes);
-
-    if(!force && newGeohashes.length === 0){
-      console.log("新たに訪れた場所がないので何も実行しません")
-      return;
-    }
-
-    // 今回追加するポリゴンを全て配列にする
-    const polygonsToMerge = newGeohashes.map(hash => this.createPolygonFromGeohash(hash));
-
-    // 過去のvisitedFeatureがあれば、それも配列に加える
-    if (this.visitedFeature) {
-      polygonsToMerge.push(this.visitedFeature);
-    }
-
-    if (polygonsToMerge.length > 1) {
-      // 配列をFeatureCollectionに変換してから、unionに渡す
-      const featureCollection = turf.featureCollection(polygonsToMerge);
-      this.visitedFeature = turf.union(featureCollection);
-    } else {
-      this.visitedFeature = polygonsToMerge[0];
-    }
-
-    let visitedUnion = turf.clone(this.visitedFeature);
-
-    // if (this.cumulativeMode && this.cumulativeFeature) {
-    //   const featureCollection = turf.featureCollection([visitedUnion, this.cumulativeFeature].filter(Boolean));
-    //   visitedUnion = turf.union(featureCollection);
-    // }
-
-    // 世界全体からvisitedを引いて霧を作る
-    const fogPolygon = turf.difference(turf.featureCollection([this.worldFeature, visitedUnion]));
-
-    if (fogPolygon) {
-      this.updateFog(fogPolygon);
-    } else {
-      console.log("fogPolygonが見つかりません");
-    }
-
-    if(this.status === STATUS.STOPPED){
-      this.resetFogData(); // 霧描画後に、保持する霧データをリセット
-    }
-  }
-
-  debugClearMassiveFog(centerLat, centerLng) {
-    const offset = 0.01;
-    const minLat = centerLat - offset;
-    const minLng = centerLng - offset;
-    const maxLat = centerLat + offset;
-    const maxLng = centerLng + offset;
-
-    // ngeohash.bboxes で範囲内のGeohash(精度9)を配列で一括取得
-    const massiveHashes = ngeohash.bboxes(minLat, minLng, maxLat, maxLng, 9);
-
-    console.log(`[負荷テスト開始] ${massiveHashes.length} 個のGeohashを一括結合します...`);
-
-    try {
-      // const resultFeature = this.generateFeatureFromGeohashes(massiveHashes, this.visitedGeohashes);
-      this.generateFeatureFromGeohashes(massiveHashes, this.visitedGeohashes);
-
-      // this.visitedFeature = resultFeature;
-      if (USE_WEBGL_FOG) {
-        this.updateRealtimeFogClearing(true)
-      } else {
-        this.executeFogClearing(true)
-      }
-
-      console.log('✅ [負荷テスト完了] オーバーフローせずに結合成功');
-    } catch (e) {
-      console.error("🚨 結合処理でエラー発生:", e);
-    }
-  }
-
-  // 累計地図の重さ確認用
-  // 指定地点周辺の geohash を大量に footprint として保存
-  async debugSaveMassiveFootprintsForCumulativeMap(centerLat, centerLng, options = {}) {
-    if (!DEBUG_MODE) return;
-
-    if (!this.tripId) {
-      console.warn("tripId がないため、デバッグ用footprintを保存できません");
-      return;
-    }
-
-    const {
-      offset = 0.005,
-      precision = GEOHASH_PRECISION,
-      step = 10,
-      maxCount = 5000,
-    } = options;
-
-    const minLat = centerLat - offset;
-    const minLng = centerLng - offset;
-    const maxLat = centerLat + offset;
-    const maxLng = centerLng + offset;
-
-    console.log("----- 累計地図デバッグ保存 開始 -----");
-    console.log({
-      centerLat,
-      centerLng,
-      offset,
-      precision,
-      step,
-      maxCount,
-      bbox: { minLat, minLng, maxLat, maxLng },
-    });
-
-    // 範囲内のgeohashを取得
-    const allHashes = ngeohash.bboxes(minLat, minLng, maxLat, maxLng, precision);
-
-    console.log(`[debug] 生成された geohash 数: ${allHashes.length}`);
-
-    // 全部保存すると多すぎるのでstep間隔で間引く
-    const sampledHashes = allHashes
-      .filter((_, index) => index % step === 0)
-      .slice(0, maxCount);
-
-    console.log(`[debug] 保存対象 geohash 数: ${sampledHashes.length}`);
-
-    if (sampledHashes.length === 0) {
-      console.warn("[debug] 保存対象がありません");
-      return;
-    }
-
-    const now = new Date();
-
-    // geohash の中心座標を footprint にする
-    const footprints = sampledHashes.map((hash, index) => {
-      const decoded = ngeohash.decode(hash);
-
-      return {
-        trip_id: this.tripId,
-        latitude: decoded.latitude,
-        longitude: decoded.longitude,
-
-        // 少しずつ時刻をずらす
-        recorded_at: new Date(now.getTime() + index * 1000).toISOString(),
-      };
-    });
-
-    await this.debugBulkCreateFootprints(footprints);
-
-    console.log("----- 累計地図デバッグ保存 終了 -----");
-  }
-
-
-  // デバッグ用ootprints一括保存
-  async debugBulkCreateFootprints(footprints) {
-    const csrfToken = document.querySelector('meta[name="csrf-token"]')?.content;
-
-    if (!csrfToken) {
-      console.error("CSRF token が見つかりません");
-      return;
-    }
-
-    const chunks = this.chunkArray(footprints, DEBUG_BULK_SAVE_CHUNK_SIZE);
-
-    console.log(`[debug] ${footprints.length}件を ${chunks.length} 回に分けて保存します`);
-
-    for (let i = 0; i < chunks.length; i++) {
-      const chunk = chunks[i];
-
-      console.log(`[debug] 保存中 ${i + 1}/${chunks.length}: ${chunk.length}件`);
-
-      try {
-        const response = await fetch(`/api/v1/trips/${this.tripId}/footprints/bulk_create`, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            "Accept": "application/json",
-            "X-CSRF-Token": csrfToken,
-          },
-          credentials: "same-origin",
-          body: JSON.stringify({ footprints: chunk }),
-        });
-
-        let result = null;
-
-        try {
-          result = await response.json();
-        } catch (_) {
-          // JSONで返らないエラー対策
-        }
-
-        if (!response.ok) {
-          console.error(`[debug] 保存失敗 ${i + 1}/${chunks.length}`, {
-            status: response.status,
-            result,
-          });
-          return;
-        }
-
-        console.log(`[debug] 保存成功 ${i + 1}/${chunks.length}`, result);
-
-        // サーバーに一気に投げすぎないため
-        await this.sleep(DEBUG_BULK_SAVE_INTERVAL_MS);
-
-      } catch (error) {
-        console.error(`[debug] 保存中にエラー ${i + 1}/${chunks.length}`, error);
-        return;
-      }
-    }
-  }
-
-  // 配列を指定サイズで分割
-  chunkArray(array, size) {
-    const chunks = [];
-
-    for (let i = 0; i < array.length; i += size) {
-      chunks.push(array.slice(i, i + size));
-    }
-
-    return chunks;
-  }
-
-  sleep(ms) {
-    return new Promise(resolve => setTimeout(resolve, ms));
-  }
-
-  // 指定されたGeohashの周辺を晴らす（デバッグ・テスト用）
-  debugClearFogAt(targetGeohash, lng, lat) {
-    this.currentGeohash = targetGeohash;
-    this.currentLng = lng;
-    this.currentLat = lat;
-    this.currentRecordTime = new Date().toISOString();
-
-    if (USE_WEBGL_FOG) {
-      this.updateRealtimeFogClearing()
-    } else {
-      this.executeFogClearing()
-    }
-
-    if(this.status === STATUS.RECORDING){
-      this.postFootprint();
-    }
   }
 
   // 地図表示前にマップを覆っているオーバーレイを消去
@@ -1059,13 +869,6 @@ export default class extends BaseMapController {
 
     // 今回のGeohashを累計Geohashに追加
     this.visitedGeohashes.forEach(hash => this.cumulativeGeohashes.add(hash));
-
-    // 累計Featureと今回のFeatureを結合
-    // if (this.cumulativeFeature) {
-    //   this.cumulativeFeature = turf.union(turf.featureCollection([this.cumulativeFeature, this.visitedFeature]));
-    // } else {
-    //   this.cumulativeFeature = turf.clone(this.visitedFeature);
-    // }
   }
 
   async cumulativeModeOn(){
@@ -1081,19 +884,11 @@ export default class extends BaseMapController {
       }
 
       this.cumulativeMode = true;
-      if (USE_WEBGL_FOG) {
-        this.updateRealtimeFogClearing(true)
-      } else {
-        this.executeFogClearing()
-      }
+      this.updateRealtimeFogClearing(true)
 
     } else if (this.cumulativeModeStatus === "isReady"){
       this.cumulativeMode = true;
-      if (USE_WEBGL_FOG) {
-        this.updateRealtimeFogClearing(true)
-      } else {
-        this.executeFogClearing()
-      }
+      this.updateRealtimeFogClearing(true)
     }
   }
 
@@ -1105,11 +900,7 @@ export default class extends BaseMapController {
     this.forceStopCumulative = true;
     this.cumulativeMode = false;
 
-    if (USE_WEBGL_FOG) {
-      this.updateRealtimeFogClearing(true)
-    } else {
-      this.executeFogClearing(true)
-    }
+    this.updateRealtimeFogClearing(true)
   }
 
   geolocateTrigger(){

--- a/app/javascript/controllers/ui_controller.js
+++ b/app/javascript/controllers/ui_controller.js
@@ -108,7 +108,8 @@ export default class extends Controller {
     this.mapOutlet.setTripId(this.tripIdValue, this.oldTripGeohashes);
     this.statusValue = STATUS.RECORDING
     this.mapOutlet.setStatus(this.statusValue);
-    this.mapOutlet.postFootprint();
+    // this.mapOutlet.postFootprint();
+    this.mapOutlet.recordStartFootprint();
     this.mapOutlet.setFlushTimer();
     this.mapOutlet.addMarkers();
     // this.mapOutlet.executeFogClearing(true);
@@ -128,7 +129,7 @@ export default class extends Controller {
   pauseRecording(){
     console.log("一時停止");
     this.mapOutlet.flushBuffer();
-    this.mapOutlet.postFootprint();
+    // this.mapOutlet.postFootprint();
     this.statusValue = STATUS.PAUSED
     this.mapOutlet.setStatus(this.statusValue);
   }

--- a/app/views/tutorials/_location_denied_modal.html.erb
+++ b/app/views/tutorials/_location_denied_modal.html.erb
@@ -8,3 +8,4 @@
         choice: false,
         content_partial: "tutorials/location_denied",
       } %>
+


### PR DESCRIPTION
## 実装内容
- this.map.on('webglcontextrestored', () => を追加
- webglcontextrestoredイベント発火時に、foginitを実行して、霧のカスタムレイヤーを再び初期化することにより、webglコンテキスト消失による霧が消えるバグを解消
- map controller,base map controllerで現在使用していない、余分な部分を適宜削除
- map_controllerに@rails/request.jsのgetを追加して、モーダルが表示されないバグを解消
- document.visibilityState === 'visible'時に、位置がズレているかもしれないので、復帰時のデータの反映と保存前にフィルターを設定
- pmtiles取得時に、rangeリクエストなのにファイル全体が返ってきてタイル取得が失敗しているっぽいので、cloudflareにpmtilesのみレスポンスヘッダー変換ルールを付与して、キャッシュコントロールに、no-transformを付与するよう設定
- cloudflareがpmtilesに圧縮等の処理をしないようにキャッシュルールを変更して、ヘッダーの設定は無視してバイパスするように
- pmtiles取得失敗時に、エラーとリロード指示のモーダルを表示
- pmtiles取得失敗時に、データをsentryに送信


## 動作確認方法
- 以下のコードをconsoleで実行し、霧のが復活することを確認。
```
const canvas = document.querySelector(".maplibregl-canvas");
const gl = canvas.getContext("webgl2") ;
const ext = gl.getExtension("WEBGL_lose_context");
ext.loseContext();
setTimeout(() => {
  console.log("restoreContext");
  ext.restoreContext();
}, 3000);
```

- pmtiles取得エラー時にもモーダルが表示されることをブラウザにて確認

## 補足
- pmtilesのエラーは解消できているか不明なので、今後も要注意
- 余裕がある時にR2バケットにあるpmtilesのファイルのcache controlヘッダーにno-transformを付与してアップし直す
