### PR TITLE
パスワード表示/非表示実装

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -58,6 +58,9 @@ application.register("map", MapController)
 import ModalController from "./modal_controller"
 application.register("modal", ModalController)
 
+import PasswordController from "./password_controller"
+application.register("password", PasswordController)
+
 import PostsController from "./posts_controller"
 application.register("posts", PostsController)
 

--- a/app/javascript/controllers/password_controller.js
+++ b/app/javascript/controllers/password_controller.js
@@ -1,0 +1,25 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="password"
+export default class extends Controller {
+  static targets = [
+    "input",
+    "eyeIcon",
+    "eyeOffIcon",
+  ]
+
+  connect() {
+  }
+
+  toggle(){
+    if(this.inputTarget.type === "text"){
+      this.inputTarget.type = "password"
+      this.eyeIconTarget.classList.remove("hidden");
+      this.eyeOffIconTarget.classList.add("hidden");
+    } else if (this.inputTarget.type === "password") {
+      this.inputTarget.type = "text"
+      this.eyeIconTarget.classList.add("hidden");
+      this.eyeOffIconTarget.classList.remove("hidden");
+    }
+  }
+}

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -27,7 +27,7 @@
       <%= f.hidden_field :reset_password_token %>
 
       <%# パスワード %>
-      <div class="field">
+      <div class="field" data-controller="password">
         <div class="flex items-center mb-2 gap-3">
           <%= f.label :password, "新しいパスワード", class: "text-sm font-bold" %>
 
@@ -39,28 +39,53 @@
         </div>
 
         <div class="relative">
-          <%= f.password_field :password, autocomplete: "new-password", placeholder: "••••••••••••••••", autofocus: true,
-              class: "w-full px-4 py-3 rounded-xl border-none shadow-sm text-gray-700 placeholder-gray-400 focus:ring-2 focus:ring-orange-300 outline-none tracking-widest" %>
+          <%= f.password_field :password,
+              required: true,
+              autocomplete: "new-password",
+              minlength: @minimum_password_length,
+              maxlength: 128,
+              placeholder: "••••••••••••••••",
+              autofocus: true,
+              class: "w-full px-4 py-3 pr-12 rounded-xl border-none shadow-sm text-gray-700 placeholder-gray-400 focus:ring-2 focus:ring-orange-300 outline-none tracking-widest",
+              data: { password_target: "input" } %>
 
-          <%# 目のアイコン（見た目のみ） %>
-          <div class="absolute inset-y-0 right-0 pr-3 flex items-center cursor-pointer text-gray-500">
-            <%= lucide_icon('eye', class: "w-6 h-6") %>
-          </div>
+          <%# 目のアイコン %>
+          <button
+            type="button"
+            class="absolute inset-y-0 right-0 pr-3 flex items-center cursor-pointer text-gray-500"
+            data-password-target="button"
+            data-action="click->password#toggle"
+          >
+            <%= lucide_icon("eye", class: "w-6 h-6", data: { password_target: "eyeIcon" }) %>
+            <%= lucide_icon("eye-off", class: "w-6 h-6 hidden", data: { password_target: "eyeOffIcon" }) %>
+          </button>
         </div>
       </div>
 
       <%# パスワード確認 %>
-      <div class="field">
+      <div class="field" data-controller="password">
         <%= f.label :password_confirmation, "新しいパスワード(確認用)", class: "block text-sm font-bold mb-2" %>
 
         <div class="relative">
-          <%= f.password_field :password_confirmation, autocomplete: "new-password", placeholder: "••••••••••••••••",
-              class: "w-full px-4 py-3 rounded-xl border-none shadow-sm text-gray-700 placeholder-gray-400 focus:ring-2 focus:ring-orange-300 outline-none tracking-widest" %>
+          <%= f.password_field :password_confirmation,
+              required: true,
+              autocomplete: "new-password",
+              minlength: @minimum_password_length,
+              maxlength: 128,
+              placeholder: "••••••••••••••••",
+              class: "w-full px-4 py-3 pr-12 rounded-xl border-none shadow-sm text-gray-700 placeholder-gray-400 focus:ring-2 focus:ring-orange-300 outline-none tracking-widest",
+              data: { password_target: "input" } %>
 
-          <%# 目のアイコン（見た目のみ） %>
-          <div class="absolute inset-y-0 right-0 pr-3 flex items-center cursor-pointer text-gray-500">
-            <%= lucide_icon('eye', class: "w-6 h-6") %>
-          </div>
+          <%# 目のアイコン %>
+          <button
+            type="button"
+            class="absolute inset-y-0 right-0 pr-3 flex items-center cursor-pointer text-gray-500"
+            data-password-target="button"
+            data-action="click->password#toggle"
+          >
+            <%= lucide_icon("eye", class: "w-6 h-6", data: { password_target: "eyeIcon" }) %>
+            <%= lucide_icon("eye-off", class: "w-6 h-6 hidden", data: { password_target: "eyeOffIcon" }) %>
+          </button>
         </div>
       </div>
 

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -20,21 +20,34 @@
       <%= render "devise/shared/error_messages", resource: resource %>
 
       <%# 現在のパスワード %>
-      <div class="field">
+      <div class="field" data-controller="password">
         <%= f.label :current_password, "現在のパスワード", class: "block text-sm font-bold mb-2" %>
         <div class="relative">
-          <%= f.password_field :current_password, required: true, autocomplete: "current-password", placeholder: "••••••••••••••••",
-              class: "w-full px-4 py-3 rounded-xl border-none shadow-sm text-gray-700 placeholder-gray-400 focus:ring-2 focus:ring-orange-300 outline-none tracking-widest" %>
+          <%= f.password_field :current_password,
+              required: true,
+              autocomplete: "current-password",
+              minlength: 6,
+              maxlength: 128,
+              placeholder: "••••••••••••••••",
+              autofocus: true,
+              class: "w-full px-4 py-3 pr-12 rounded-xl border-none shadow-sm text-gray-700 placeholder-gray-400 focus:ring-2 focus:ring-orange-300 outline-none tracking-widest",
+              data: { password_target: "input" } %>
 
           <%# 目のアイコン %>
-          <div class="absolute inset-y-0 right-0 pr-3 flex items-center cursor-pointer text-gray-500">
-            <%= lucide_icon('eye', class: "w-6 h-6") %>
-          </div>
+          <button
+            type="button"
+            class="absolute inset-y-0 right-0 pr-3 flex items-center cursor-pointer text-gray-500"
+            data-password-target="button"
+            data-action="click->password#toggle"
+          >
+            <%= lucide_icon("eye", class: "w-6 h-6", data: { password_target: "eyeIcon" }) %>
+            <%= lucide_icon("eye-off", class: "w-6 h-6 hidden", data: { password_target: "eyeOffIcon" }) %>
+          </button>
         </div>
       </div>
 
       <%# 新しいパスワード %>
-      <div class="field">
+      <div class="field" data-controller="password">
         <div class="flex items-center mb-2 gap-3">
           <%= f.label :password, "新しいパスワード", class: "text-sm font-bold" %>
 
@@ -46,28 +59,52 @@
         </div>
 
         <div class="relative">
-          <%= f.password_field :password, required: true, autocomplete: "new-password", placeholder: "••••••••••••••••",
-              class: "w-full px-4 py-3 rounded-xl border-none shadow-sm text-gray-700 placeholder-gray-400 focus:ring-2 focus:ring-orange-300 outline-none tracking-widest" %>
+          <%= f.password_field :password,
+              required: true,
+              autocomplete: "new-password",
+              minlength: @minimum_password_length,
+              maxlength: 128,
+              placeholder: "••••••••••••••••",
+              class: "w-full px-4 py-3 pr-12 rounded-xl border-none shadow-sm text-gray-700 placeholder-gray-400 focus:ring-2 focus:ring-orange-300 outline-none tracking-widest",
+              data: { password_target: "input" } %>
 
-          <%# 目のアイコン（見た目のみ） %>
-          <div class="absolute inset-y-0 right-0 pr-3 flex items-center cursor-pointer text-gray-500">
-            <%= lucide_icon('eye', class: "w-6 h-6") %>
-          </div>
+          <%# 目のアイコン %>
+          <button
+            type="button"
+            class="absolute inset-y-0 right-0 pr-3 flex items-center cursor-pointer text-gray-500"
+            data-password-target="button"
+            data-action="click->password#toggle"
+          >
+            <%= lucide_icon("eye", class: "w-6 h-6", data: { password_target: "eyeIcon" }) %>
+            <%= lucide_icon("eye-off", class: "w-6 h-6 hidden", data: { password_target: "eyeOffIcon" }) %>
+          </button>
         </div>
       </div>
 
       <%# 新しいパスワード確認 %>
-      <div class="field">
+      <div class="field" data-controller="password">
         <%= f.label :password_confirmation, "新しいパスワード(確認用)", class: "block text-sm font-bold mb-2" %>
 
         <div class="relative">
-          <%= f.password_field :password_confirmation, required: true, autocomplete: "new-password", placeholder: "••••••••••••••••",
-              class: "w-full px-4 py-3 rounded-xl border-none shadow-sm text-gray-700 placeholder-gray-400 focus:ring-2 focus:ring-orange-300 outline-none tracking-widest" %>
+          <%= f.password_field :password_confirmation,
+              required: true,
+              autocomplete: "new-password",
+              minlength: @minimum_password_length,
+              maxlength: 128,
+              placeholder: "••••••••••••••••",
+              class: "w-full px-4 py-3 pr-12 rounded-xl border-none shadow-sm text-gray-700 placeholder-gray-400 focus:ring-2 focus:ring-orange-300 outline-none tracking-widest",
+              data: { password_target: "input" } %>
 
-          <%# 目のアイコン（見た目のみ） %>
-          <div class="absolute inset-y-0 right-0 pr-3 flex items-center cursor-pointer text-gray-500">
-            <%= lucide_icon('eye', class: "w-6 h-6") %>
-          </div>
+          <%# 目のアイコン %>
+          <button
+            type="button"
+            class="absolute inset-y-0 right-0 pr-3 flex items-center cursor-pointer text-gray-500"
+            data-password-target="button"
+            data-action="click->password#toggle"
+          >
+            <%= lucide_icon("eye", class: "w-6 h-6", data: { password_target: "eyeIcon" }) %>
+            <%= lucide_icon("eye-off", class: "w-6 h-6 hidden", data: { password_target: "eyeOffIcon" }) %>
+          </button>
         </div>
       </div>
 

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -31,7 +31,7 @@
       </div>
 
       <%# パスワード %>
-      <div class="field">
+      <div class="field" data-controller="password">
         <div class="flex items-center mb-2 gap-3">
           <%= f.label :password, "パスワード", class: "text-sm font-bold" %>
 
@@ -43,28 +43,53 @@
         </div>
 
         <div class="relative">
-          <%= f.password_field :password, required: true, autocomplete: "new-password", placeholder: "••••••••••••••••",
-              class: "w-full px-4 py-3 rounded-xl border-none shadow-sm text-gray-700 placeholder-gray-400 focus:ring-2 focus:ring-orange-300 outline-none tracking-widest" %>
+          <%= f.password_field :password,
+              required: true,
+              autocomplete: "new-password",
+              minlength: @minimum_password_length,
+              maxlength: 128,
+              placeholder: "••••••••••••••••",
+              autofocus: true,
+              class: "w-full px-4 py-3 pr-12 rounded-xl border-none shadow-sm text-gray-700 placeholder-gray-400 focus:ring-2 focus:ring-orange-300 outline-none tracking-widest",
+              data: { password_target: "input" } %>
 
-          <%# 目のアイコン（見た目のみ） %>
-          <div class="absolute inset-y-0 right-0 pr-3 flex items-center cursor-pointer text-gray-500">
-            <%= lucide_icon('eye', class: "w-6 h-6") %>
-          </div>
+          <%# 目のアイコン %>
+          <button
+            type="button"
+            class="absolute inset-y-0 right-0 pr-3 flex items-center cursor-pointer text-gray-500"
+            data-password-target="button"
+            data-action="click->password#toggle"
+          >
+            <%= lucide_icon("eye", class: "w-6 h-6", data: { password_target: "eyeIcon" }) %>
+            <%= lucide_icon("eye-off", class: "w-6 h-6 hidden", data: { password_target: "eyeOffIcon" }) %>
+          </button>
         </div>
       </div>
 
       <%# パスワード確認 %>
-      <div class="field">
+      <div class="field" data-controller="password">
         <%= f.label :password_confirmation, "パスワード(確認用)", class: "block text-sm font-bold mb-2" %>
 
         <div class="relative">
-          <%= f.password_field :password_confirmation, required: true, autocomplete: "new-password", placeholder: "••••••••••••••••",
-              class: "w-full px-4 py-3 rounded-xl border-none shadow-sm text-gray-700 placeholder-gray-400 focus:ring-2 focus:ring-orange-300 outline-none tracking-widest" %>
+          <%= f.password_field :password_confirmation,
+              required: true,
+              autocomplete: "new-password",
+              minlength: @minimum_password_length,
+              maxlength: 128,
+              placeholder: "••••••••••••••••",
+              class: "w-full px-4 py-3 pr-12 rounded-xl border-none shadow-sm text-gray-700 placeholder-gray-400 focus:ring-2 focus:ring-orange-300 outline-none tracking-widest",
+              data: { password_target: "input" } %>
 
-          <%# 目のアイコン（見た目のみ） %>
-          <div class="absolute inset-y-0 right-0 pr-3 flex items-center cursor-pointer text-gray-500">
-            <%= lucide_icon('eye', class: "w-6 h-6") %>
-          </div>
+          <%# 目のアイコン %>
+          <button
+            type="button"
+            class="absolute inset-y-0 right-0 pr-3 flex items-center cursor-pointer text-gray-500"
+            data-password-target="button"
+            data-action="click->password#toggle"
+          >
+            <%= lucide_icon("eye", class: "w-6 h-6", data: { password_target: "eyeIcon" }) %>
+            <%= lucide_icon("eye-off", class: "w-6 h-6 hidden", data: { password_target: "eyeOffIcon" }) %>
+          </button>
         </div>
       </div>
 

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -21,21 +21,33 @@
       <%# メールアドレス %>
       <div class="field">
         <%= f.label :email, "メールアドレス", class: "block text-sm font-bold mb-2" %>
-        <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "shiroichizu@shiroichizu.app",
+        <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "shiroichizu@shiroichizu.app", required: true,
             class: "w-full px-4 py-3 rounded-xl border-none shadow-sm text-gray-700 placeholder-gray-400 focus:ring-2 focus:ring-orange-300 outline-none" %>
       </div>
 
       <%# パスワード %>
-      <div class="field">
+      <div class="field" data-controller="password">
         <%= f.label :password, "パスワード", class: "block text-sm font-bold mb-2" %>
         <div class="relative">
-          <%= f.password_field :password, autocomplete: "current-password", placeholder: "••••••••••••••••",
-              class: "w-full px-4 py-3 rounded-xl border-none shadow-sm text-gray-700 placeholder-gray-400 focus:ring-2 focus:ring-orange-300 outline-none tracking-widest" %>
+          <%= f.password_field :password,
+              required: true,
+              autocomplete: "current-password",
+              minlength: 6,
+              maxlength: 128,
+              placeholder: "••••••••••••••••",
+              class: "w-full px-4 py-3 pr-12 rounded-xl border-none shadow-sm text-gray-700 placeholder-gray-400 focus:ring-2 focus:ring-orange-300 outline-none tracking-widest",
+              data: { password_target: "input" } %>
 
           <%# 目のアイコン %>
-          <div class="absolute inset-y-0 right-0 pr-3 flex items-center cursor-pointer text-gray-500">
-            <%= lucide_icon('eye', class: "w-6 h-6") %>
-          </div>
+          <button
+            type="button"
+            class="absolute inset-y-0 right-0 pr-3 flex items-center cursor-pointer text-gray-500"
+            data-password-target="button"
+            data-action="click->password#toggle"
+          >
+            <%= lucide_icon("eye", class: "w-6 h-6", data: { password_target: "eyeIcon" }) %>
+            <%= lucide_icon("eye-off", class: "w-6 h-6 hidden", data: { password_target: "eyeOffIcon" }) %>
+          </button>
         </div>
       </div>
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -180,7 +180,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :validatable
   # Range for password length.
-  config.password_length = 6..128
+  config.password_length = 8..128
 
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly


### PR DESCRIPTION
## issue
- close: #191 

## 実装内容
- password_controller.js作成
- パスワードのinputのtypeをpasswordとtextに切り替えて表示/非表示を変更するtoggleメソッド作成
- パスワード変更ページにパスワードの表示/非表示を切り替えるdata-actionを追加
- パスワード再設定ページにパスワードの表示/非表示を切り替えるdata-actionを追加
- 新規登録ページにパスワードの表示/非表示を切り替えるdata-actionを追加
- ログインページにパスワードの表示/非表示を切り替えるdata-actionを追加

## issueとの差分
- なし

## 動作確認方法
- ブラウザでパスワードに入力した文字の表示/非表示の切り替えが可能か確認
