### PR TITLE
post-images-worker 修正

### DIFF
--- a/app/javascript/controllers/base_map_controller.js
+++ b/app/javascript/controllers/base_map_controller.js
@@ -138,6 +138,8 @@ export default class extends Controller {
     const error = event.error;
     const message = error?.message || "";
 
+    this.mapInitEnd = true;
+
     console.warn("[map:error]", error);
 
     const isPmtilesByteServingError =
@@ -192,6 +194,7 @@ export default class extends Controller {
 
       const styleJson = await res.json();
       this.constructor.styleJsonCache = structuredClone(styleJson);
+
       return structuredClone(styleJson);
     } catch (error) {
       if (error.name === "AbortError") {

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -274,6 +274,7 @@ export default class extends BaseMapController {
 
   // geolocate発火時のコールバック関数
   handleGeolocate = (data) => {
+    console.log("handleGeolacate起動")
     if (!this.map || !this.element.isConnected) return; // ガード
 
     this.updateCurrentPositionState(data);

--- a/workers/post-images-worker/src/index.js
+++ b/workers/post-images-worker/src/index.js
@@ -10,7 +10,6 @@
 
 export default {
 	async fetch(request, env, ctx) {
-		console.log(getCookie(request, "media_access_grant"))
 		const url = new URL(request.url);
 		const match = url.pathname.match(/^\/(?:variants\/)?posts\/(\d+)\/(.+)$/);
 
@@ -43,6 +42,7 @@ export default {
 		// R2のカスタムドメインへ流す
     const upstreamUrl = new URL(request.url);
 		upstreamUrl.hostname = env.MEDIA_ORIGIN_HOST;
+		upstreamUrl.search = ""; // クエリでキャッシュを分散させない
 
 		const upstreamRequest = new Request(upstreamUrl.toString(), {
 			method: "GET",
@@ -64,8 +64,13 @@ export default {
 			},
 		});
 
+		// 新しいResponseオブジェクトを作る
 		const res = new Response(originRes.body, originRes);
 
+		// 不要なヘッダーを削除
+		res.headers.delete("set-cookie");
+
+		// キャッシュヘッダーを上書き
 		if ((originRes.status >= 200 && originRes.status < 300) || originRes.status === 304) {
 			res.headers.set(
 				"Cache-Control",
@@ -76,8 +81,6 @@ export default {
 		} else {
 			res.headers.set("Cache-Control", "no-store");
 		}
-
-		console.log(res)
 
 		return res;
 	}


### PR DESCRIPTION
- workerからR2バケットへのアクセスのレスポンスにcloudflare Accessで付与されるset-cookieを削除するよう実装。ユーザーのcookieにCF_Authorizationが付与されることによりキャッシュの汚染等の予期せぬ不具合を防止するため。