### PR TITLE
投稿表示画面修正完了

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -90,6 +90,21 @@ class PostsController < ApplicationController
     preview
   end
 
+  def show_body
+    @post = Post.includes(:trip, :user).find_by(public_uid: params[:id])
+
+    if @post.nil?
+      return respond_modal("shared/flash_message", flash_message: { alert: "投稿が見つかりません" })
+    end
+
+    if @post.visible_to?(current_user)
+      MediaAccessGrantService.call(posts: @post, cookies: cookies)
+      respond_modal
+    else
+      respond_modal("shared/flash_message", flash_message: { alert: "この投稿は表示できません" })
+    end
+  end
+
   def image_viewer
     preview
   end

--- a/app/javascript/controllers/base_map_controller.js
+++ b/app/javascript/controllers/base_map_controller.js
@@ -393,7 +393,7 @@ export default class extends Controller {
           'default-pin'          // 読み込み前や画像なしはデフォルト画像
         ],
         'icon-anchor': 'center',  // ピンの位置
-        'icon-size': 0.5,
+        'icon-size': 0.6,
         'icon-allow-overlap': true
       }
     });

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -109,7 +109,6 @@ export default class extends BaseMapController {
         timeout: GEOLOCATE_TIMEOUT
       },
       trackUserLocation: true, // 移動に合わせてドットが動く
-      showUserHeading: true, // スマホの向いている方角を表示
       showAccuracyCircle: false, // GPSの誤差の範囲を表示
       fitBoundsOptions: { // ズームカメラの設定
       }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,7 +16,7 @@
     <%# googleフォント %>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c&family=Noto+Sans+JP:wght@100..900&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Klee+One&family=M+PLUS+Rounded+1c&family=Noto+Sans+JP:wght@100..900&display=swap" rel="stylesheet">
 
     <%# PWA & Icons %>
     <link rel="manifest" href="/manifest.json">

--- a/app/views/posts/_scrapbook_memo.html.erb
+++ b/app/views/posts/_scrapbook_memo.html.erb
@@ -1,0 +1,59 @@
+<%# locals: (post:, width_class: "w-[86%]", offset_class: "", line_class: "line-clamp-3", open_body_link: true) %>
+
+<% if post.body.present? %>
+  <% memo_content = capture do %>
+    <section class="relative">
+      <div class="relative border border-[#e4d3af] bg-[#f6ecd6] px-7 pb-5 pt-4 pl-8 text-[#574d41] shadow-[0_8px_18px_rgba(45,35,20,0.14)]">
+        <div class="absolute -top-4 left-1/2 h-6 w-24 -translate-x-1/2 rotate-2 border border-[#b59c70]/45 bg-[#d6c298]/85 shadow-sm"></div>
+
+        <div
+          class="absolute bottom-4 left-2 top-4 w-2 opacity-90"
+          style="
+            background-image: radial-gradient(circle, #d0c1a4 0 3.5px, transparent 4px);
+            background-size: 8px 28px;
+            background-repeat: repeat-y;
+            background-position: top center;
+            filter: drop-shadow(inset 0 1px 1px rgba(0, 0, 0, 0.18));
+          "
+        ></div>
+
+        <div
+          class="pointer-events-none absolute bottom-4 left-6 right-4 top-4 opacity-[0.14]"
+          style="
+            background-image: repeating-linear-gradient(
+              to bottom,
+              transparent 0px,
+              transparent 27px,
+              #b9ab8c 27px,
+              #b9ab8c 28px
+            );
+          "
+        ></div>
+
+        <p
+          class="relative z-10 <%= line_class %> min-h-[5.25rem] whitespace-pre-wrap break-words font-serif text-[14px] leading-7 tracking-[0.04em] text-[#4f4639]"
+          style="font-family: 'Klee One', 'Zen Kurenaido', 'Hiragino Mincho ProN', serif;"
+        ><%= post.body %></p>
+
+        <div class="absolute bottom-3 right-3 h-12 w-6 opacity-60">
+          <div class="absolute bottom-0 left-1/2 h-11 w-px origin-bottom rotate-[18deg] bg-[#b9a36f]"></div>
+          <div class="absolute bottom-8 left-1 h-2 w-2 rounded-full bg-[#d8bf6c]"></div>
+          <div class="absolute bottom-5 right-1 h-1.5 w-1.5 rounded-full bg-[#d8bf6c]"></div>
+          <div class="absolute bottom-10 right-0 h-1.5 w-1.5 rounded-full bg-[#d8bf6c]"></div>
+        </div>
+      </div>
+    </section>
+  <% end %>
+
+  <% if open_body_link %>
+    <%= link_to show_body_post_path(post),
+                class: "block relative #{width_class} -rotate-1 #{offset_class}",
+                data: { turbo_stream: true } do %>
+      <%= memo_content %>
+    <% end %>
+  <% else %>
+    <div class="block relative <%= width_class %> -rotate-1 <%= offset_class %>">
+      <%= memo_content %>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/posts/_scrapbook_photo.html.erb
+++ b/app/views/posts/_scrapbook_photo.html.erb
@@ -1,0 +1,35 @@
+<%# locals: (post:, image:, index:, rotate_class:, width_class:, offset_class: "", z_class: "") %>
+
+<article class="relative <%= width_class %> <%= rotate_class %> <%= offset_class %> <%= z_class %>">
+  <div
+    class="relative border border-white/90 bg-[#fffdf7] p-1.5 pb-6 shadow-[0_8px_18px_rgba(45,35,20,0.14)] ring-1 ring-[#ead9bf]/70"
+    data-controller="image-loader"
+  >
+    <div class="relative aspect-square overflow-hidden bg-[#eee7db]">
+
+      <%# ローディング表示 %>
+      <div
+        class="absolute inset-0 z-10 flex items-center justify-center bg-[#eee7db] transition-opacity"
+        data-image-loader-target="placeholder"
+      >
+        <div class="h-8 w-8 animate-spin rounded-full border-2 border-stone-200 border-t-stone-500"></div>
+      </div>
+
+      <%= link_to image_viewer_post_path(post, index: index),
+                  data: { turbo_stream: true },
+                  class: "block h-full w-full" do %>
+        <%= image_tag media_image_url(image.variant(:thumb).key),
+                      loading: "lazy",
+                      class: "h-full w-full object-cover opacity-0 transition-opacity duration-300",
+                      data: {
+                        image_loader_target: "image",
+                        action: "load->image-loader#loaded error->image-loader#error"
+                      } %>
+      <% end %>
+    </div>
+
+    <p class="absolute bottom-1.5 left-2 right-2 truncate text-center font-serif text-[11px] leading-none text-[#5f594e]">
+      <%#= ここに写真のタイトルを入れる可能性あり %>
+    </p>
+  </div>
+</article>

--- a/app/views/posts/preview.turbo_stream.erb
+++ b/app/views/posts/preview.turbo_stream.erb
@@ -1,138 +1,61 @@
 <%= turbo_stream.update "bottom-sheet-container" do %>
-  <div class="fixed inset-0 h-full pointer-events-none opacity-0 w-full z-40 flex flex-col justify-end transition-all duration-300" data-controller="bottom-sheet">
+  <% images = @post.images.to_a.first(6) %>
+  <% image_count = images.size %>
 
-    <%# --- バックドロップ --- %>
-    <div class="absolute inset-0 bg-black/50 z-0 pointer-events-auto" data-bottom-sheet-target="bottomSheetBackdrop" data-action="click->bottom-sheet#close"></div>
+  <div
+    class="fixed inset-0 z-40 h-dvh w-full pointer-events-none opacity-0 transition-all duration-300"
+    data-controller="bottom-sheet"
+  >
+    <div
+      class="absolute inset-0 z-0 bg-black/20 pointer-events-auto"
+      data-bottom-sheet-target="bottomSheetBackdrop"
+      data-action="click->bottom-sheet#close"
+    ></div>
 
-    <%# --- ボトムシート全体 --- %>
-    <div data-bottom-sheet-target="bottomSheetBox"
-          class="relative inset-x-0 bottom-0 z-10 flex flex-col w-full max-h-[60vh] rounded-t-3xl bg-[#FFFBE6] pb-11 pt-8 shadow-[0_-5px_20px_rgba(0,0,0,0.1)] transition-transform translate-y-full duration-300 pointer-events-auto">
+    <div
+      data-bottom-sheet-target="bottomSheetBox"
+      class="absolute inset-x-0 top-12 bottom-0 z-10 overflow-hidden bg-transparent pointer-events-auto transition-transform duration-300 translate-y-full"
+    >
+      <%# 右上操作ボタン %>
+      <div class="absolute right-4 top-2 z-[100] flex items-center gap-2">
 
-      <%# --- ドラッグハンドル --- %>
-      <div class="absolute mx-auto mb-2 h-1.5 w-12 shrink-0 rounded-full bg-gray-400 top-3 left-1/2 -translate-x-1/2"></div>
-
-      <%# --- ヘッダー --- %>
-      <div class="modal-header shrink-0 z-20 w-full px-2 sm:px-4">
-        <div class="flex items-center justify-between border-b border-orange-200/60 pb-3 gap-2">
-
-          <%# 左上コンテナ %>
-          <div class="flex items-center gap-3 flex-1 min-w-0">
-
-            <%# アイコン %>
-            <div class="shrink-0">
-              <% if @post.user.avatar.attached? %>
-                <%= image_tag avatar_url(@post.user), class: "w-10 h-10 object-cover rounded-full shadow-sm" %>
-              <% else %>
-                <div class="w-10 h-10 bg-orange-400 rounded-full flex items-center justify-center shadow-sm">
-                  <%= lucide_icon('user-round', class: "w-6 h-6 text-white") %>
-                </div>
-              <% end %>
-            </div>
-
-            <%# ユーザー名と日時 %>
-            <div class="flex flex-col justify-center gap-1 flex-1 min-w-0">
-              <div class="font-bold text-gray-800 text-base truncate">
-                <%= @post.user.nickname %>
-              </div>
-              <div class="text-sm text-gray-500 font-medium truncate">
-                <%= @post.visited_at&.strftime("%Y/%m/%d %H:%M") %>
-              </div>
-            </div>
-
-          </div>
-
-          <%# --- 右上コンテナ --- %>
-          <div class="flex items-center gap-3 shrink-0">
-
-            <%# --- 三点リーダボタン --- %>
-            <% if @post.user_id == current_user.id %>
-              <div class="relative" data-controller="dropdown" data-dropdown-post-url-value="<%= confirm_destroy_post_path(@post) %>">
-                <button type="button"
-                        class="h-10 w-10 flex items-center justify-center bg-gray-500/50 hover:bg-gray-600/60 text-white rounded-full transition"
-                        data-action="click->dropdown#toggle">
-                  <%= lucide_icon('ellipsis-vertical', class: "w-6 h-6") %>
-                </button>
-              </div>
-            <% end %>
-
-            <%# --- バツボタン --- %>
-            <button class="h-10 w-10 flex items-center justify-center bg-gray-500/50 hover:bg-gray-600/60 text-white rounded-full transition" data-action="click->bottom-sheet#close">
-              <%= lucide_icon('x', class: "w-6 h-6") %>
+        <%# 三点リーダボタン %>
+        <% if @post.user_id == current_user&.id %>
+          <div
+            class="relative"
+            data-controller="dropdown"
+            data-dropdown-post-url-value="<%= confirm_destroy_post_path(@post) %>"
+          >
+            <button
+              type="button"
+              class="flex h-8 w-8 items-center justify-center rounded-full bg-white/90 text-stone-700 shadow-lg backdrop-blur-md transition hover:bg-white active:scale-95"
+              data-action="click->dropdown#toggle"
+            >
+              <%= lucide_icon("ellipsis", class: "h-5 w-5") %>
             </button>
-
           </div>
-        </div>
+        <% end %>
+
+        <%# バツボタン %>
+        <button
+          type="button"
+          class="flex h-8 w-8 items-center justify-center rounded-full bg-white/90 text-stone-700 shadow-lg backdrop-blur-md transition hover:bg-white active:scale-95"
+          data-action="click->bottom-sheet#close"
+        >
+          <%= lucide_icon "x", class: "h-6 w-6" %>
+        </button>
+
       </div>
 
-      <%# --- メインコンテンツ--- %>
-      <%= link_to post_path(@post),
-                  class: "w-full flex-1 min-h-0 flex",
-                  data: { turbo_stream: true, bottom_sheet_target: "bottomSheetBox" } do %>
+      <div class="absolute left-4 top-5 z-[90] rounded-full bg-black/25 px-3 py-1.5 text-xs leading-none text-white/95 shadow-sm backdrop-blur-md">
+        <%= @post.visited_at&.strftime("%Y/%m/%d %H:%M") %>
+      </div>
 
-        <div class="flex-1 min-h-0 flex flex-col px-4 pb-4 gap-3 w-full max-w-xl mx-auto">
-
-          <%# 本文 %>
-          <% if @post.body.present? %>
-            <% text_classes = @post.images.attached? ? "line-clamp-3 shrink-0 pt-3" : "pt-3" %>
-
-            <div class="text-gray-700 text-base whitespace-pre-wrap leading-tight font-medium <%= text_classes %>"><%= @post.body %></div>
-          <% end %>
-
-          <%# 画像エリア %>
-          <% if @post.images.attached? %>
-            <div class="w-full flex-1 min-h-0 pt-3">
-
-              <% image_count = @post.images.size %>
-
-              <%# --- 画像が1枚だけの場合 --- %>
-              <% if image_count == 1 %>
-                <div class="relative w-full min-h-[220px] max-h-[32vh] flex-1 overflow-hidden rounded-xl" data-controller="image-loader">
-                  <div class="absolute inset-0 flex items-center justify-center transition-opacity" data-image-loader-target="placeholder">
-                    <div class="w-10 h-10 border-2 border-gray-200 border-t-gray-500 rounded-full animate-spin"></div>
-                  </div>
-                  <%= image_tag media_image_url(@post.images.first.variant(:thumb).key),
-                                loading: "lazy",
-                                class: "absolute inset-0 w-full h-full object-contain rounded-xl shadow-sm opacity-0 transition-opacity duration-300",
-                                data: {
-                                  image_loader_target: "image",
-                                  action: "load->image-loader#loaded error->image-loader#error"
-                                } %>
-                </div>
-
-              <%# --- 画像が複数ある場合 --- %>
-              <% else %>
-                <div class="grid grid-cols-2 gap-1 w-full min-h-0  rounded-xl overflow-hidden">
-                  <% @post.images.first(4).each_with_index do |image, index| %>
-                    <div class="relative w-full aspect-[4/3] max-h-[15dvh]" data-controller="image-loader" style="container-type: inline-size;">
-                      <div class="absolute inset-0 flex items-center justify-center transition-opacity px-1 overflow-hidden" data-image-loader-target="placeholder">
-                        <div class="w-10 h-10 border-2 border-gray-200 border-t-gray-500 rounded-full animate-spin"></div>
-                      </div>
-                      <%= image_tag media_image_url(image.variant(:thumb).key), loading: "lazy",
-                            class: "absolute inset-0 w-full h-full object-cover shadow-sm opacity-0 transition-opacity duration-300",
-                            data: {
-                              image_loader_target: "image",
-                              action: "load->image-loader#loaded error->image-loader#error"
-                            } %>
-
-                      <% if index == 3 && image_count > 4 %>
-                        <div class="absolute inset-0 bg-black/60 flex items-center justify-center">
-                          <span class="text-white font-bold tracking-wider text-center" style="font-size: 25cqw;">
-                            + <%= image_count - 4 %>
-                          </span>
-                        </div>
-                      <% end %>
-                    </div>
-                  <% end %>
-                </div>
-              <% end %>
-
-            </div>
-          <% end %>
-
-        </div>
-
-      <% end %>
-
+      <div class="absolute inset-0 z-20 overflow-hidden px-4 pb-4 pt-14">
+        <%= render "posts/scrapbook_layouts/count_#{image_count}",
+                    post: @post,
+                    images: images %>
+      </div>
     </div>
   </div>
 <% end %>

--- a/app/views/posts/scrapbook_layouts/_count_0.html.erb
+++ b/app/views/posts/scrapbook_layouts/_count_0.html.erb
@@ -1,0 +1,6 @@
+<div class="mx-auto flex h-full w-full max-w-[390px] items-center justify-center">
+  <%= render "posts/scrapbook_memo",
+              post: post,
+              width_class: "w-[86%]",
+              line_class: "line-clamp-6" %>
+</div>

--- a/app/views/posts/scrapbook_layouts/_count_1.html.erb
+++ b/app/views/posts/scrapbook_layouts/_count_1.html.erb
@@ -1,0 +1,18 @@
+<div class="mx-auto grid h-full w-full max-w-[390px] grid-cols-1 grid-rows-[1fr_auto] items-center gap-y-6">
+  <div class="flex min-h-0 min-w-0 items-center justify-center">
+    <%= render "posts/scrapbook_photo",
+                post: post,
+                image: images[0],
+                index: 0,
+                rotate_class: "-rotate-3",
+                width_class: "w-[85%]",
+                offset_class: "-translate-y-8" %>
+  </div>
+
+  <div class="flex min-w-0 items-center justify-center -translate-y-[100px]">
+    <%= render "posts/scrapbook_memo",
+                post: post,
+                width_class: "w-[86%]",
+                line_class: "line-clamp-3" %>
+  </div>
+</div>

--- a/app/views/posts/scrapbook_layouts/_count_2.html.erb
+++ b/app/views/posts/scrapbook_layouts/_count_2.html.erb
@@ -1,0 +1,28 @@
+<div class="mx-auto grid h-full w-full max-w-[390px] grid-cols-1 grid-rows-[1fr_auto_1fr] items-center gap-y-5">
+  <div class="flex min-h-0 min-w-0 items-center justify-center">
+    <%= render "posts/scrapbook_photo",
+                post: post,
+                image: images[0],
+                index: 0,
+                rotate_class: "-rotate-3",
+                width_class: "w-[64%]",
+                offset_class: "-translate-y-2",
+                z_class: "z-20" %>
+  </div>
+
+  <div class="flex min-w-0 items-center justify-center">
+    <%= render "posts/scrapbook_memo",
+                post: post,
+                width_class: "w-[86%]" %>
+  </div>
+
+  <div class="flex min-h-0 min-w-0 items-center justify-center">
+    <%= render "posts/scrapbook_photo",
+                image: images[1],
+                post: post,
+                index: 1,
+                rotate_class: "rotate-3",
+                width_class: "w-[64%]",
+                offset_class: "translate-y-1" %>
+  </div>
+</div>

--- a/app/views/posts/scrapbook_layouts/_count_3.html.erb
+++ b/app/views/posts/scrapbook_layouts/_count_3.html.erb
@@ -1,0 +1,37 @@
+<div class="mx-auto grid h-full w-full max-w-[390px] grid-cols-2 grid-rows-[1fr_auto_1fr] items-center gap-x-5 gap-y-4">
+  <div class="flex min-h-0 min-w-0 items-center justify-center">
+    <%= render "posts/scrapbook_photo",
+                post: post,
+                image: images[0],
+                index: 0,
+                rotate_class: "-rotate-3",
+                width_class: "w-[90%]",
+                offset_class: "translate-y-2" %>
+  </div>
+
+  <div class="flex min-h-0 min-w-0 items-center justify-center">
+    <%= render "posts/scrapbook_photo",
+                post: post,
+                image: images[1],
+                index: 1,
+                rotate_class: "rotate-3",
+                width_class: "w-[90%]",
+                offset_class: "-translate-y-1" %>
+  </div>
+
+  <div class="col-span-2 flex min-w-0 items-center justify-center">
+    <%= render "posts/scrapbook_memo",
+                post: post,
+                width_class: "w-[86%]" %>
+  </div>
+
+  <div class="col-span-2 flex min-h-0 min-w-0 items-center justify-center">
+    <%= render "posts/scrapbook_photo",
+                post: post,
+                image: images[2],
+                index: 2,
+                rotate_class: "-rotate-2",
+                width_class: "w-[55%]",
+                offset_class: "-translate-y-2" %>
+  </div>
+</div>

--- a/app/views/posts/scrapbook_layouts/_count_4.html.erb
+++ b/app/views/posts/scrapbook_layouts/_count_4.html.erb
@@ -1,0 +1,31 @@
+<% slots = [0, 1, :memo, 2, 3] %>
+
+<div class="mx-auto grid h-full w-full max-w-[390px] grid-cols-2 grid-rows-[minmax(0,1fr)_auto_minmax(0,1fr)] items-center gap-x-5 gap-y-1">
+  <% rotate_classes = ["-rotate-3", "rotate-3", "-rotate-2", "rotate-2"] %>
+  <% offset_classes = ["translate-y-1", "-translate-y-1", "translate-y-1", "-translate-y-1"] %>
+
+  <% slots.each do |slot| %>
+    <% if slot == :memo %>
+      <div class="col-span-2 z-30 flex min-w-0 items-center justify-center">
+        <%= render "posts/scrapbook_memo",
+                    post: post,
+                    width_class: "w-[84%]" %>
+      </div>
+    <% else %>
+      <% index = slot %>
+
+      <%# 上段は下寄せ、下段は上寄せ %>
+      <% vertical_align_class = index < 2 ? "items-end" : "items-start" %>
+
+      <div class="flex min-h-0 min-w-0 <%= vertical_align_class %> justify-center overflow-visible">
+        <%= render "posts/scrapbook_photo",
+                    post: post,
+                    image: images[index],
+                    index: index,
+                    rotate_class: rotate_classes[index],
+                    width_class: "w-[90%]",
+                    offset_class: offset_classes[index] %>
+      </div>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/posts/scrapbook_layouts/_count_5.html.erb
+++ b/app/views/posts/scrapbook_layouts/_count_5.html.erb
@@ -1,0 +1,43 @@
+<div class="mx-auto grid h-full w-full max-w-[390px] grid-cols-2 grid-rows-[1fr_1fr_auto_1fr] items-center gap-x-5 gap-y-2">
+  <% rotate_classes = ["-rotate-3", "rotate-3", "-rotate-2", "rotate-2", "-rotate-2"] %>
+  <% offset_classes = ["-translate-y-4", "-translate-y-5", "-translate-y-2", "-translate-y-3", "translate-y-1"] %>
+
+  <%# 各画像のz index %>
+  <% z_classes = [
+    "z-20",
+    "z-20",
+    "z-20",
+    "z-20",
+    "z-20"
+  ] %>
+
+  <% images.first(4).each_with_index do |image, index| %>
+    <div class="flex min-h-0 min-w-0 items-center justify-center">
+      <%= render "posts/scrapbook_photo",
+                  post: post,
+                  image: image,
+                  index: index,
+                  rotate_class: rotate_classes[index],
+                  width_class: "w-[78%]",
+                  offset_class: offset_classes[index],
+                  z_class: z_classes[index] %>
+    </div>
+  <% end %>
+
+  <div class="col-span-2 flex min-w-0 items-center justify-center -translate-y-1 z-10">
+    <%= render "posts/scrapbook_memo",
+                post: post,
+                width_class: "w-[84%]" %>
+  </div>
+
+  <div class="col-span-2 flex min-h-0 min-w-0 items-center justify-center">
+    <%= render "posts/scrapbook_photo",
+                post: post,
+                image: images[4],
+                index: 4,
+                rotate_class: rotate_classes[4],
+                width_class: "w-[42%]",
+                offset_class: offset_classes[4],
+                z_class: z_classes[4] %>
+  </div>
+</div>

--- a/app/views/posts/scrapbook_layouts/_count_6.html.erb
+++ b/app/views/posts/scrapbook_layouts/_count_6.html.erb
@@ -1,0 +1,66 @@
+<% slots = [0, 1, 2, 3, :memo, 4, 5] %>
+
+<%# 各写真の角度 %>
+<% rotate_classes = [
+  "-rotate-[2deg]",
+  "rotate-[3deg]",
+  "-rotate-[6deg]",
+  "rotate-[2deg]",
+  "rotate-[2deg]",
+  "rotate-[4deg]"
+] %>
+
+<%# 各画像の横幅 %>
+<% width_classes = [
+  "w-[81%]",
+  "w-[81%]",
+  "w-[78%]",
+  "w-[78%]",
+  "w-[79%]",
+  "w-[79%]"
+] %>
+
+<%# 各画像の位置 %>
+<% offset_classes = [
+  "-translate-x-2 -translate-y-2",
+  "translate-x-2 -translate-y-3",
+  "-translate-x-1 translate-y-0",
+  "translate-x-2 -translate-y-1",
+  "-translate-x-4 translate-y-1",
+  "translate-x-1 translate-y-1"
+] %>
+
+<%# 各画像のz index %>
+<% z_classes = [
+  "z-40",
+  "z-40",
+  "z-40",
+  "z-40",
+  "z-40",
+  "z-40"
+] %>
+
+<div class="mx-auto grid h-full w-full max-w-[388px] grid-cols-2 grid-rows-[1fr_1fr_auto_1fr] items-center gap-x-0 gap-y-0">
+  <% slots.each do |slot| %>
+    <% if slot == :memo %>
+      <div class="col-span-2 flex min-w-0 items-center justify-center translate-y-0 z-30">
+        <%= render "posts/scrapbook_memo",
+                    post: post,
+                    width_class: "w-[82%]" %>
+      </div>
+    <% else %>
+      <% index = slot %>
+
+      <div class="flex min-h-0 min-w-0 items-center justify-center overflow-visible">
+        <%= render "posts/scrapbook_photo",
+                    image: images[index],
+                    post: post,
+                    index: index,
+                    rotate_class: rotate_classes[index],
+                    width_class: width_classes[index],
+                    offset_class: offset_classes[index],
+                    z_class: z_classes[index] %>
+      </div>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/posts/show_body.turbo_stream.erb
+++ b/app/views/posts/show_body.turbo_stream.erb
@@ -1,0 +1,52 @@
+<%= turbo_stream.append "modal-container" do %>
+  <div
+    class="fixed inset-0 z-40 flex h-dvh w-full items-stretch justify-center p-0 opacity-0 pointer-events-none transition-all duration-300 sm:items-center sm:p-4 lg:p-10"
+    data-controller="modal"
+  >
+    <%# --- バックドロップ --- %>
+    <div
+      class="modal-backdrop absolute inset-0 z-0 bg-black/50 pointer-events-auto"
+      data-modal-target="modalBackdrop"
+      data-action="click->modal#close"
+    ></div>
+
+    <%# --- モーダル枠 --- %>
+    <div
+      class="modal-box relative z-10 flex h-full w-full max-w-none translate-y-40 flex-col items-center gap-4 rounded-none px-0 pb-6 pt-1 opacity-0 pointer-events-auto transition-all duration-500 ease-out sm:h-auto sm:max-h-[90dvh] sm:max-w-xl sm:rounded-xl sm:pt-2 overflow-visible"
+      data-modal-target="modalBox"
+    >
+      <%# --- ヘッダー --- %>
+      <div class="modal-header z-20 w-full shrink-0 px-2 pt-2 sm:px-4">
+        <div class="flex items-center justify-between pb-3">
+          <div class="flex items-center gap-3"></div>
+
+          <div class="flex items-center gap-3">
+            <button
+              type="button"
+              class="flex h-10 w-10 items-center justify-center rounded-full bg-gray-500/50 text-white transition hover:bg-gray-600/60"
+              data-action="click->modal#close"
+            >
+              <%= lucide_icon("x", class: "w-6 h-6") %>
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <%# --- モーダル本文 --- %>
+      <div class="modal-body min-h-0 w-full flex-1 overflow-y-auto overscroll-contain px-3 pb-10 pt-8 sm:px-6 sm:pb-12 sm:pt-10">
+        <% if @post.body.present? %>
+          <div class="mx-auto flex w-full max-w-3xl justify-center">
+            <div class="flex w-full justify-center pt-4">
+              <%= render "posts/scrapbook_memo",
+                          post: @post,
+                          width_class: "w-[92%] sm:w-[82%]",
+                          offset_class: "",
+                          line_class: "",
+                          open_body_link: false %>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -58,6 +58,7 @@ Rails.application.routes.draw do
       post :cluster_preview
     end
     member do
+      get :show_body
       get :preview
       get :image_viewer
       get :confirm_destroy


### PR DESCRIPTION
## issue
- close: #196 

## 実装内容
- google fontsで「Klee One」を導入
- postのbodyだけを表示するposts#show_bodyを作成
- postを表示するビューの中身を刷新
- 添付画像枚数ごとに表示の仕方が違うpartialを作成
- posts#preivewからは投稿の詳細表示を行わず、画像のみの拡大表示と、本文の全体をshow_bodyで表示するように変更

## issueとの差分
- posts#showは変更せずに、本文のみを表示するshow_bodyアクションとルーティングを追加
- posts#previewで使用するpartialを追加

## 動作確認方法
- PCのブラウザで投稿に添付画像0~6枚と文章ありなし全てのパターンで想定通りに表示されているのか確認
- スマホのブラウザで投稿に添付画像0~6枚と文章ありなし全てのパターンで想定通りに表示されているのか確認

## 補足
- スマホの機種によっては表示が想定通りにいかないかのせいがあるので、要チェック
