### PR TITLE
brakeman.ignore追加、dependabot.yml修正

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,10 +3,28 @@ updates:
 - package-ecosystem: bundler
   directory: "/"
   schedule:
-    interval: daily
-  open-pull-requests-limit: 10
+    interval: "weekly"
+    day: "monday"
+    time: "09:00"
+    timezone: "Asia/Tokyo"
+
+  ignore:
+    # connection_pool 3.xは過去にエラーが発生したため保留
+    - dependency-name: "connection_pool"
+      update-types:
+        - "version-update:semver-major"
+
+    # Devise 5.xは破壊的変更の確認が必要なため保留
+    - dependency-name: "devise"
+      update-types:
+        - "version-update:semver-major"
+
+  open-pull-requests-limit: 5
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
-    interval: daily
-  open-pull-requests-limit: 10
+    interval: "weekly"
+    day: "monday"
+    time: "09:00"
+    timezone: "Asia/Tokyo"
+  open-pull-requests-limit: 5

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,0 +1,24 @@
+{
+  "ignored_warnings": [
+    {
+      "warning_type": "Unmaintained Dependency",
+      "warning_code": 122,
+      "fingerprint": "21ab0fe00fdd5899ffc405cff75aadb91b805ee996a614f7e27b08a287e9062d",
+      "check_name": "EOLRails",
+      "message": "Support for Rails 7.2.3.1 ends on 2026-08-09",
+      "file": "Gemfile.lock",
+      "line": 311,
+      "link": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
+      "code": null,
+      "render_path": null,
+      "location": null,
+      "user_input": null,
+      "confidence": "Weak",
+      "cwe_id": [
+        1104
+      ],
+      "note": "Rails 7.2.3.1 is still supported until 2026-08-09. Temporarily accepted during job search; upgrade planned before EOL."
+    }
+  ],
+  "brakeman_version": "7.1.2"
+}


### PR DESCRIPTION
- Rails7.2のサポート期限が切れるエラーがbrakemanで発生するため、一旦brakeman.ignoreを作成して、エラーにならないように追加
  - 8/9までにはrails8へのアップデートを行う
- 意図的に追加していないgemのPRが作成されないように、dependabotの中にignoreを追加
  - connection_pool 3.xは過去にエラーが発生したため保留
  - Devise 5.xは破壊的変更の確認が必要なため保留