### PR TITLE
未ログインユーザーが探索開始した時のリダイレクト先を変更

### DIFF
--- a/app/controllers/api/v1/trips_controller.rb
+++ b/app/controllers/api/v1/trips_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::TripsController < ApplicationController
-  before_action :authenticate_user!
+  before_action :require_user_for_trip
 
   def create
     last_trip = current_user&.trips&.last # 最後の探索を取得
@@ -82,6 +82,12 @@ class Api::V1::TripsController < ApplicationController
   end
 
   private
+
+  def require_user_for_trip
+    return if user_signed_in?
+
+    redirect_to mypage_path, alert: "ゲスト登録かログインが必要です"
+  end
 
   def execute_create_trip
     trip = current_user&.trips&.build


### PR DESCRIPTION
## 実装内容
- Api::V1::TripsControllerにrequire_user_for_tripメソッドを追加
- 同コントローラー内で、before_action :authenticate_user!としていたのをbefore_action :require_user_for_tripに変更
## 理由
- 現状だと、未ログインユーザーが探索ボタンを押した時に、ログインページにリダイレクトしていた
- ログインページにはゲストで始められるという情報がどこにも記載されていないため、ゲスト機能に気づかずに離脱する人を減らす目的でリダイレクト先を変更
- 新しいリダイレクト先はmypage_pathで、ゲスト利用、新規登録、ログイン、全てが一画面で表示されているため最適だと思われる