### PR TITLE
累計地図にgeojson形式のposts表示機能実装

### DIFF
--- a/app/controllers/my_maps_controller.rb
+++ b/app/controllers/my_maps_controller.rb
@@ -1,9 +1,38 @@
 class MyMapsController < ApplicationController
   def show
     if user_signed_in?
-      @first_footprint = current_user&.footprints.first
-      @visited_geohashes = current_user&.cumulative_geohashes || []
-      @posts = current_user&.posts || []
+      respond_to do |format|
+        format.html do
+          @first_footprint = current_user&.footprints.first
+          @visited_geohashes = current_user&.cumulative_geohashes || []
+          @posts = current_user&.posts || []
+        end
+
+        format.json do
+          @posts = current_user.posts.includes(images_attachments: :blob)
+
+          features = @posts&.map do |post|
+            {
+              type: "Feature",
+              geometry: {
+                type: "Point",
+                coordinates: [ post.longitude, post.latitude ]
+              },
+              properties: {
+                public_uid: post.public_uid,
+                icon_url: post.images.attached? ? helpers.media_image_url(post.images.first.variant(:map_icon).key) : "",
+                is_icon_loaded: false
+              }
+            }
+          end
+
+          MediaAccessGrantService.call(posts: @posts, cookies: cookies)
+          render json: {
+            type: "FeatureCollection",
+            features: features
+          }
+        end
+      end
     else
       flash[:alert] = "この機能はゲストか会員しか使えません"
       redirect_to new_user_session_path

--- a/app/views/my_maps/show.html.erb
+++ b/app/views/my_maps/show.html.erb
@@ -33,7 +33,7 @@
       data-history-map-longitude-value="<%= @first_footprint&.longitude %>"
       data-history-map-latitude-value="<%= @first_footprint&.latitude %>"
       data-history-map-visited-geohashes-value=""
-      data-history-map-posts-value="<%= @posts.to_json %>"
+      data-history-map-posts-url-value="<%= my_map_path(format: :json) %>"
     >
 
       <%# オーバレイ要素 %>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -164,6 +164,8 @@ Devise.setup do |config|
 
   # ==> Configuration for :rememberable
   # The time the user will be remembered without asking for credentials again.
+
+  # remember_expires_atをuser.rbで新たに定義しているため、ここのは使用されない
   config.remember_for = 2.weeks
 
   # Invalidates all the remember me tokens when the user signs out.


### PR DESCRIPTION
## issue
- close: #241 

## 実装内容
- my_maps#showにpostsをjsonで表示するための機能を実装
- my_maps/show.html.erbにpostsのデータを取得する用のurlをpostsUrlValueとして追加

## issueとの差分
- 特になし

## 動作確認方法
- ログインユーザーで、my_maps.jsonにアクセスして自分のデータしか表示されないことを確認

## 補足
- 累計地図を公開できるようにした場合に、postsの公開設定による表示、非表示の設定を追加すること
